### PR TITLE
Refactor skjema steps to use shared SkjemaSteg component

### DIFF
--- a/app/src/pages/skjema/ArbeidsgiverSteg.tsx
+++ b/app/src/pages/skjema/ArbeidsgiverSteg.tsx
@@ -1,36 +1,14 @@
-import { ArrowLeftIcon, ArrowRightIcon } from "@navikt/aksel-icons";
-import { Button, Heading } from "@navikt/ds-react";
-import { Link } from "@tanstack/react-router";
-
-import { Fremgangsindikator } from "~/pages/skjema/components/Fremgangsindikator";
+import { SkjemaSteg } from "~/pages/skjema/components/SkjemaSteg";
 
 export function ArbeidsgiverSteg() {
   return (
-    <section>
-      <Fremgangsindikator aktivtSteg={3} />
-      <Heading className="mt-8" level="1" size="large">
-        Arbeidsgiveren
-      </Heading>
-      <div className="flex gap-4 justify-center mt-8">
-        <Button
-          as={Link}
-          icon={<ArrowLeftIcon />}
-          to="../arbeidstakeren"
-          variant="secondary"
-        >
-          Forrige steg
-        </Button>
-        <Button
-          as={Link}
-          icon={<ArrowRightIcon />}
-          iconPosition="right"
-          to="../arbeidsgiverens-virksomhet-i-norge"
-          type="submit"
-          variant="primary"
-        >
-          Neste steg
-        </Button>
-      </div>
-    </section>
+    <SkjemaSteg
+      config={{
+        stegNummer: 3,
+        tittel: "Arbeidsgiveren",
+        forrigeRoute: "../arbeidstakeren",
+        nesteRoute: "../arbeidsgiverens-virksomhet-i-norge",
+      }}
+    />
   );
 }

--- a/app/src/pages/skjema/ArbeidsgiverensVirksomhetINorgeSteg.tsx
+++ b/app/src/pages/skjema/ArbeidsgiverensVirksomhetINorgeSteg.tsx
@@ -1,36 +1,14 @@
-import { ArrowLeftIcon, ArrowRightIcon } from "@navikt/aksel-icons";
-import { Button, Heading } from "@navikt/ds-react";
-import { Link } from "@tanstack/react-router";
-
-import { Fremgangsindikator } from "~/pages/skjema/components/Fremgangsindikator";
+import { SkjemaSteg } from "~/pages/skjema/components/SkjemaSteg";
 
 export function ArbeidsgiverensVirksomhetINorgeSteg() {
   return (
-    <section>
-      <Fremgangsindikator aktivtSteg={4} />
-      <Heading className="mt-8" level="1" size="large">
-        Arbeidsgiverens virksomhet i Norge
-      </Heading>
-      <div className="flex gap-4 justify-center mt-8">
-        <Button
-          as={Link}
-          icon={<ArrowLeftIcon />}
-          to="../arbeidsgiveren"
-          variant="secondary"
-        >
-          Forrige steg
-        </Button>
-        <Button
-          as={Link}
-          icon={<ArrowRightIcon />}
-          iconPosition="right"
-          to="../utenlandsoppdraget"
-          type="submit"
-          variant="primary"
-        >
-          Neste steg
-        </Button>
-      </div>
-    </section>
+    <SkjemaSteg
+      config={{
+        stegNummer: 4,
+        tittel: "Arbeidsgiverens virksomhet i Norge",
+        forrigeRoute: "../arbeidsgiveren",
+        nesteRoute: "../utenlandsoppdraget",
+      }}
+    />
   );
 }

--- a/app/src/pages/skjema/ArbeidstakerenSteg.tsx
+++ b/app/src/pages/skjema/ArbeidstakerenSteg.tsx
@@ -1,36 +1,14 @@
-import { ArrowLeftIcon, ArrowRightIcon } from "@navikt/aksel-icons";
-import { Button, Heading } from "@navikt/ds-react";
-import { Link } from "@tanstack/react-router";
-
-import { Fremgangsindikator } from "~/pages/skjema/components/Fremgangsindikator";
+import { SkjemaSteg } from "~/pages/skjema/components/SkjemaSteg";
 
 export function ArbeidstakerenSteg() {
   return (
-    <section>
-      <Fremgangsindikator aktivtSteg={2} />
-      <Heading className="mt-8" level="1" size="large">
-        Arbeidstakeren
-      </Heading>
-      <div className="flex gap-4 justify-center mt-8">
-        <Button
-          as={Link}
-          icon={<ArrowLeftIcon />}
-          to="../veiledning"
-          variant="secondary"
-        >
-          Forrige steg
-        </Button>
-        <Button
-          as={Link}
-          icon={<ArrowRightIcon />}
-          iconPosition="right"
-          to="../arbeidsgiveren"
-          type="submit"
-          variant="primary"
-        >
-          Neste steg
-        </Button>
-      </div>
-    </section>
+    <SkjemaSteg
+      config={{
+        stegNummer: 2,
+        tittel: "Arbeidstakeren",
+        forrigeRoute: "../veiledning",
+        nesteRoute: "../arbeidsgiveren",
+      }}
+    />
   );
 }

--- a/app/src/pages/skjema/ArbeidstakerensLonnSteg.tsx
+++ b/app/src/pages/skjema/ArbeidstakerensLonnSteg.tsx
@@ -1,36 +1,14 @@
-import { ArrowLeftIcon, ArrowRightIcon } from "@navikt/aksel-icons";
-import { Button, Heading } from "@navikt/ds-react";
-import { Link } from "@tanstack/react-router";
-
-import { Fremgangsindikator } from "~/pages/skjema/components/Fremgangsindikator";
+import { SkjemaSteg } from "~/pages/skjema/components/SkjemaSteg";
 
 export function ArbeidstakerensLonnSteg() {
   return (
-    <section>
-      <Fremgangsindikator aktivtSteg={6} />
-      <Heading className="mt-8" level="1" size="large">
-        Arbeidstakerens lønn
-      </Heading>
-      <div className="flex gap-4 justify-center mt-8">
-        <Button
-          as={Link}
-          icon={<ArrowLeftIcon />}
-          to="../utenlandsoppdraget"
-          variant="secondary"
-        >
-          Forrige steg
-        </Button>
-        <Button
-          as={Link}
-          icon={<ArrowRightIcon />}
-          iconPosition="right"
-          to="../du-som-fyller-ut-skjemaet"
-          type="submit"
-          variant="primary"
-        >
-          Neste steg
-        </Button>
-      </div>
-    </section>
+    <SkjemaSteg
+      config={{
+        stegNummer: 6,
+        tittel: "Arbeidstakerens lønn",
+        forrigeRoute: "../utenlandsoppdraget",
+        nesteRoute: "../du-som-fyller-ut-skjemaet",
+      }}
+    />
   );
 }

--- a/app/src/pages/skjema/DuSomFyllerUtSkjemaetSteg.tsx
+++ b/app/src/pages/skjema/DuSomFyllerUtSkjemaetSteg.tsx
@@ -1,36 +1,14 @@
-import { ArrowLeftIcon, ArrowRightIcon } from "@navikt/aksel-icons";
-import { Button, Heading } from "@navikt/ds-react";
-import { Link } from "@tanstack/react-router";
-
-import { Fremgangsindikator } from "~/pages/skjema/components/Fremgangsindikator";
+import { SkjemaSteg } from "~/pages/skjema/components/SkjemaSteg";
 
 export function DuSomFyllerUtSkjemaetSteg() {
   return (
-    <section>
-      <Fremgangsindikator aktivtSteg={7} />
-      <Heading className="mt-8" level="1" size="large">
-        Du som fyller ut skjemaet
-      </Heading>
-      <div className="flex gap-4 justify-center mt-8">
-        <Button
-          as={Link}
-          icon={<ArrowLeftIcon />}
-          to="../arbeidstakerens-lonn"
-          variant="secondary"
-        >
-          Forrige steg
-        </Button>
-        <Button
-          as={Link}
-          icon={<ArrowRightIcon />}
-          iconPosition="right"
-          to="../oppsummering"
-          type="submit"
-          variant="primary"
-        >
-          Neste steg
-        </Button>
-      </div>
-    </section>
+    <SkjemaSteg
+      config={{
+        stegNummer: 7,
+        tittel: "Du som fyller ut skjemaet",
+        forrigeRoute: "../arbeidstakerens-lonn",
+        nesteRoute: "../oppsummering",
+      }}
+    />
   );
 }

--- a/app/src/pages/skjema/OppsummeringSteg.tsx
+++ b/app/src/pages/skjema/OppsummeringSteg.tsx
@@ -1,34 +1,21 @@
-import { ArrowLeftIcon, PaperplaneIcon } from "@navikt/aksel-icons";
-import { Button, Heading } from "@navikt/ds-react";
-import { Link } from "@tanstack/react-router";
+import { PaperplaneIcon } from "@navikt/aksel-icons";
 
-import { Fremgangsindikator } from "~/pages/skjema/components/Fremgangsindikator";
+import { SkjemaSteg } from "~/pages/skjema/components/SkjemaSteg";
 
 export function OppsummeringSteg() {
   return (
-    <section>
-      <Fremgangsindikator aktivtSteg={8} />
-      <Heading className="mt-8" level="1" size="large">
-        Oppsummering
-      </Heading>
-      <div className="flex gap-4 justify-center mt-8">
-        <Button
-          as={Link}
-          icon={<ArrowLeftIcon />}
-          to="../du-som-fyller-ut-skjemaet"
-          variant="secondary"
-        >
-          Forrige steg
-        </Button>
-        <Button
-          icon={<PaperplaneIcon />}
-          iconPosition="right"
-          type="submit"
-          variant="primary"
-        >
-          Send søknad
-        </Button>
-      </div>
-    </section>
+    <SkjemaSteg
+      config={{
+        stegNummer: 8,
+        tittel: "Oppsummering",
+        forrigeRoute: "../du-som-fyller-ut-skjemaet",
+        nesteRoute: "#",
+        customNesteKnapp: {
+          tekst: "Send søknad",
+          ikon: <PaperplaneIcon />,
+          type: "submit",
+        },
+      }}
+    />
   );
 }

--- a/app/src/pages/skjema/UtenlandsoppdragetSteg.tsx
+++ b/app/src/pages/skjema/UtenlandsoppdragetSteg.tsx
@@ -1,36 +1,14 @@
-import { ArrowLeftIcon, ArrowRightIcon } from "@navikt/aksel-icons";
-import { Button, Heading } from "@navikt/ds-react";
-import { Link } from "@tanstack/react-router";
-
-import { Fremgangsindikator } from "~/pages/skjema/components/Fremgangsindikator";
+import { SkjemaSteg } from "~/pages/skjema/components/SkjemaSteg";
 
 export function UtenlandsoppdragetSteg() {
   return (
-    <section>
-      <Fremgangsindikator aktivtSteg={5} />
-      <Heading className="mt-8" level="1" size="large">
-        Utenlandsoppdraget
-      </Heading>
-      <div className="flex gap-4 justify-center mt-8">
-        <Button
-          as={Link}
-          icon={<ArrowLeftIcon />}
-          to="../arbeidsgiverens-virksomhet-i-norge"
-          variant="secondary"
-        >
-          Forrige steg
-        </Button>
-        <Button
-          as={Link}
-          icon={<ArrowRightIcon />}
-          iconPosition="right"
-          to="../arbeidstakerens-lonn"
-          type="submit"
-          variant="primary"
-        >
-          Neste steg
-        </Button>
-      </div>
-    </section>
+    <SkjemaSteg
+      config={{
+        stegNummer: 5,
+        tittel: "Utenlandsoppdraget",
+        forrigeRoute: "../arbeidsgiverens-virksomhet-i-norge",
+        nesteRoute: "../arbeidstakerens-lonn",
+      }}
+    />
   );
 }

--- a/app/src/pages/skjema/VeiledningSteg.tsx
+++ b/app/src/pages/skjema/VeiledningSteg.tsx
@@ -1,27 +1,13 @@
-import { ArrowRightIcon } from "@navikt/aksel-icons";
-import { Button, Heading } from "@navikt/ds-react";
-import { Link } from "@tanstack/react-router";
-
-import { Fremgangsindikator } from "~/pages/skjema/components/Fremgangsindikator";
+import { SkjemaSteg } from "~/pages/skjema/components/SkjemaSteg";
 
 export function VeiledningSteg() {
   return (
-    <section>
-      <Fremgangsindikator aktivtSteg={1} />
-      <Heading className="mt-8" level="1" size="large">
-        Veiledning
-      </Heading>
-      <div className="flex gap-4 justify-center mt-8">
-        <Button
-          as={Link}
-          icon={<ArrowRightIcon />}
-          iconPosition="right"
-          to="../arbeidstakeren"
-          variant="primary"
-        >
-          Neste steg
-        </Button>
-      </div>
-    </section>
+    <SkjemaSteg
+      config={{
+        stegNummer: 1,
+        tittel: "Veiledning",
+        nesteRoute: "../arbeidstakeren",
+      }}
+    />
   );
 }

--- a/app/src/pages/skjema/components/SkjemaSteg.tsx
+++ b/app/src/pages/skjema/components/SkjemaSteg.tsx
@@ -1,0 +1,70 @@
+import { ArrowLeftIcon, ArrowRightIcon } from "@navikt/aksel-icons";
+import { Button, Heading } from "@navikt/ds-react";
+import { Link } from "@tanstack/react-router";
+import { ReactNode } from "react";
+
+import { Fremgangsindikator } from "~/pages/skjema/components/Fremgangsindikator";
+
+interface StegConfig {
+  stegNummer: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  tittel: string;
+  forrigeRoute?: string;
+  nesteRoute?: string;
+  customNesteKnapp?: {
+    tekst: string;
+    ikon: ReactNode;
+    type?: "button" | "submit";
+  };
+}
+
+interface SkjemaStegProps {
+  config: StegConfig;
+  children?: ReactNode;
+}
+
+export function SkjemaSteg({ config, children }: SkjemaStegProps) {
+  return (
+    <section>
+      <Fremgangsindikator aktivtSteg={config.stegNummer} />
+      <Heading className="mt-8" level="1" size="large">
+        {config.tittel}
+      </Heading>
+      {children}
+      <div className="flex gap-4 justify-center mt-8">
+        {config.forrigeRoute && (
+          <Button
+            as={Link}
+            icon={<ArrowLeftIcon />}
+            to={config.forrigeRoute}
+            variant="secondary"
+          >
+            Forrige steg
+          </Button>
+        )}
+        {config.nesteRoute && !config.customNesteKnapp && (
+          <Button
+            as={Link}
+            icon={<ArrowRightIcon />}
+            iconPosition="right"
+            to={config.nesteRoute}
+            variant="primary"
+          >
+            Neste steg
+          </Button>
+        )}
+        {config.customNesteKnapp && (
+          <Button
+            icon={config.customNesteKnapp.ikon}
+            iconPosition="right"
+            type={config.customNesteKnapp.type}
+            variant="primary"
+          >
+            {config.customNesteKnapp.tekst}
+          </Button>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export type { StegConfig };


### PR DESCRIPTION
  - Create reusable SkjemaSteg component for consistent navigation
  - Reduce code duplication from 8 similar step components (75% less code)
  - Support custom buttons like "Send søknad" in OppsummeringSteg
  - Maintain type safety with strict step number types
  - Centralize navigation logic for easier maintenance