### PR TITLE
Låse fnr felt i arbeidstakeren steg til fnr til innlogget bruker

### DIFF
--- a/app/src/components/RadioGroupJaNeiFormPart.tsx
+++ b/app/src/components/RadioGroupJaNeiFormPart.tsx
@@ -1,4 +1,5 @@
 import { Radio, RadioGroup, RadioGroupProps } from "@navikt/ds-react";
+import { useEffect } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
@@ -17,12 +18,25 @@ export function RadioGroupJaNeiFormPart({
   lockedValue,
   ...props
 }: RadioGroupJaNeiProps) {
-  const { control } = useFormContext();
+  const { control, setValue } = useFormContext();
   const { t } = useTranslation();
   const translateError = useTranslateError();
 
-  const lockedValueString =
-    lockedValue === undefined ? undefined : lockedValue.toString();
+  useEffect(() => {
+    if (lockedValue !== undefined) {
+      setValue(formFieldName, lockedValue);
+    }
+  }, [lockedValue, formFieldName, setValue]);
+
+  const lockedValueOrElseFieldValue = (fieldValue: boolean) => {
+    if (lockedValue !== undefined) {
+      return lockedValue.toString();
+    }
+    if (fieldValue === undefined) {
+      return "";
+    }
+    return fieldValue.toString();
+  };
 
   return (
     <Controller
@@ -33,13 +47,7 @@ export function RadioGroupJaNeiFormPart({
           {...props}
           error={translateError(fieldState.error?.message)}
           onChange={(value) => field.onChange(value === "true")}
-          value={
-            lockedValueString === undefined
-              ? field.value === undefined
-                ? ""
-                : field.value.toString()
-              : lockedValueString
-          }
+          value={lockedValueOrElseFieldValue(field.value)}
         >
           <Radio size="small" value="true">
             {t("felles.ja")}

--- a/app/src/components/RadioGroupJaNeiFormPart.tsx
+++ b/app/src/components/RadioGroupJaNeiFormPart.tsx
@@ -28,16 +28,6 @@ export function RadioGroupJaNeiFormPart({
     }
   }, [lockedValue, formFieldName, setValue]);
 
-  const lockedValueOrElseFieldValue = (fieldValue: boolean) => {
-    if (lockedValue !== undefined) {
-      return lockedValue.toString();
-    }
-    if (fieldValue === undefined) {
-      return "";
-    }
-    return fieldValue.toString();
-  };
-
   return (
     <Controller
       control={control}
@@ -47,7 +37,7 @@ export function RadioGroupJaNeiFormPart({
           {...props}
           error={translateError(fieldState.error?.message)}
           onChange={(value) => field.onChange(value === "true")}
-          value={lockedValueOrElseFieldValue(field.value)}
+          value={field.value === undefined ? "" : field.value.toString()}
         >
           <Radio size="small" value="true">
             {t("felles.ja")}

--- a/app/src/components/RadioGroupJaNeiFormPart.tsx
+++ b/app/src/components/RadioGroupJaNeiFormPart.tsx
@@ -6,18 +6,23 @@ import { useTranslateError } from "~/utils/translation.ts";
 
 type RadioGroupJaNeiProps = Omit<
   RadioGroupProps,
-  "onChange" | "value" | "children" | "error"
+  "onChange" | "children" | "error"
 > & {
   formFieldName: string;
+  lockedValue?: boolean;
 };
 
 export function RadioGroupJaNeiFormPart({
   formFieldName,
+  lockedValue,
   ...props
 }: RadioGroupJaNeiProps) {
   const { control } = useFormContext();
   const { t } = useTranslation();
   const translateError = useTranslateError();
+
+  const lockedValueString =
+    lockedValue === undefined ? undefined : lockedValue.toString();
 
   return (
     <Controller
@@ -28,7 +33,13 @@ export function RadioGroupJaNeiFormPart({
           {...props}
           error={translateError(fieldState.error?.message)}
           onChange={(value) => field.onChange(value === "true")}
-          value={field.value === undefined ? "" : field.value.toString()}
+          value={
+            lockedValueString === undefined
+              ? field.value === undefined
+                ? ""
+                : field.value.toString()
+              : lockedValueString
+          }
         >
           <Radio size="small" value="true">
             {t("felles.ja")}

--- a/app/src/pages/skjema/arbeidstaker/ArbeidstakerenSteg.tsx
+++ b/app/src/pages/skjema/arbeidstaker/ArbeidstakerenSteg.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Select, TextField, VStack } from "@navikt/ds-react";
+import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -9,6 +10,7 @@ import { DatePickerFormPart } from "~/components/DatePickerFormPart.tsx";
 import { NorskeVirksomheterFormPart } from "~/components/NorskeVirksomheterFormPart.tsx";
 import { RadioGroupJaNeiFormPart } from "~/components/RadioGroupJaNeiFormPart.tsx";
 import { UtenlandskeVirksomheterFormPart } from "~/components/UtenlandskeVirksomheterFormPart.tsx";
+import { getUserInfo } from "~/httpClients/dekoratorenClient.ts";
 import { ARBEIDSTAKER_STEG_REKKEFOLGE } from "~/pages/skjema/arbeidstaker/stegRekkefølge.ts";
 import {
   getNextStep,
@@ -28,6 +30,12 @@ export function ArbeidstakerenSteg() {
   const { t } = useTranslation();
   const translateError = useTranslateError();
 
+  const userInfo = useQuery(getUserInfo()).data;
+
+  const innloggetBrukerHarNorskFodselsnummer = userInfo?.userId
+    ? /^\d{11}$/.test(userInfo.userId)
+    : false;
+
   type ArbeidstakerFormData = z.infer<typeof arbeidstakerSchema>;
 
   const formMethods = useForm<ArbeidstakerFormData>({
@@ -41,7 +49,8 @@ export function ArbeidstakerenSteg() {
     watch,
   } = formMethods;
 
-  const harNorskFodselsnummer = watch("harNorskFodselsnummer");
+  const harNorskFodselsnummer =
+    watch("harNorskFodselsnummer") || innloggetBrukerHarNorskFodselsnummer;
   const harVaertEllerSkalVaereILonnetArbeidFoerUtsending = watch(
     "harVaertEllerSkalVaereILonnetArbeidFoerUtsending",
   );
@@ -72,10 +81,12 @@ export function ArbeidstakerenSteg() {
         >
           <RadioGroupJaNeiFormPart
             className="mt-4"
+            disabled={innloggetBrukerHarNorskFodselsnummer}
             formFieldName="harNorskFodselsnummer"
             legend={t(
               "arbeidstakerenSteg.harArbeidstakerenNorskFodselsnummerEllerDNummer",
             )}
+            lockedValue={innloggetBrukerHarNorskFodselsnummer}
           />
 
           {harNorskFodselsnummer && (
@@ -88,6 +99,8 @@ export function ArbeidstakerenSteg() {
               size="medium"
               style={{ maxWidth: "160px" }}
               {...register("fodselsnummer")}
+              disabled={innloggetBrukerHarNorskFodselsnummer}
+              value={userInfo?.userId}
             />
           )}
 

--- a/app/src/pages/skjema/arbeidstaker/ArbeidstakerenSteg.tsx
+++ b/app/src/pages/skjema/arbeidstaker/ArbeidstakerenSteg.tsx
@@ -2,6 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Select, TextField, VStack } from "@navikt/ds-react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
@@ -47,9 +48,16 @@ export function ArbeidstakerenSteg() {
     handleSubmit,
     formState: { errors },
     watch,
+    setValue,
   } = formMethods;
 
   const innloggetBrukerHarNorskFodselsnummer = userInfo?.userId !== undefined;
+
+  useEffect(() => {
+    if (innloggetBrukerHarNorskFodselsnummer) {
+      setValue("fodselsnummer", userInfo.userId);
+    }
+  }, [innloggetBrukerHarNorskFodselsnummer, userInfo?.userId, setValue]);
 
   const harNorskFodselsnummer =
     watch("harNorskFodselsnummer") || innloggetBrukerHarNorskFodselsnummer;
@@ -110,9 +118,6 @@ export function ArbeidstakerenSteg() {
               style={{ maxWidth: "160px" }}
               {...register("fodselsnummer")}
               disabled={innloggetBrukerHarNorskFodselsnummer}
-              {...(innloggetBrukerHarNorskFodselsnummer
-                ? { value: userInfo?.userId }
-                : {})}
             />
           )}
 

--- a/app/src/pages/skjema/arbeidstaker/ArbeidstakerenSteg.tsx
+++ b/app/src/pages/skjema/arbeidstaker/ArbeidstakerenSteg.tsx
@@ -30,11 +30,11 @@ export function ArbeidstakerenSteg() {
   const { t } = useTranslation();
   const translateError = useTranslateError();
 
-  const userInfo = useQuery(getUserInfo()).data;
-
-  const innloggetBrukerHarNorskFodselsnummer = userInfo?.userId
-    ? /^\d{11}$/.test(userInfo.userId)
-    : false;
+  const {
+    data: userInfo,
+    isLoading: userInfoIsLoading,
+    error: userinfoIsError,
+  } = useQuery(getUserInfo());
 
   type ArbeidstakerFormData = z.infer<typeof arbeidstakerSchema>;
 
@@ -48,6 +48,8 @@ export function ArbeidstakerenSteg() {
     formState: { errors },
     watch,
   } = formMethods;
+
+  const innloggetBrukerHarNorskFodselsnummer = userInfo?.userId !== undefined;
 
   const harNorskFodselsnummer =
     watch("harNorskFodselsnummer") || innloggetBrukerHarNorskFodselsnummer;
@@ -65,6 +67,14 @@ export function ArbeidstakerenSteg() {
       navigate({ to: nextStep.route });
     }
   };
+
+  if (userInfoIsLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (userinfoIsError) {
+    return <div>Error loading user info</div>;
+  }
 
   return (
     <FormProvider {...formMethods}>
@@ -100,7 +110,9 @@ export function ArbeidstakerenSteg() {
               style={{ maxWidth: "160px" }}
               {...register("fodselsnummer")}
               disabled={innloggetBrukerHarNorskFodselsnummer}
-              value={userInfo?.userId}
+              {...(innloggetBrukerHarNorskFodselsnummer
+                ? { value: userInfo?.userId }
+                : {})}
             />
           )}
 


### PR DESCRIPTION
Denne delen vil i fremtiden bli tilpasset tilfeller der man opererer på vegne av en annen person. Mtp at det er et stykke unna tenkte jeg at vi foreløping kan låse "Har arbeidstakeren norsk fødselsnummer eller d-nummer?" til "ja", preutfyller fnr og låser feltene for input.