### PR TITLE
7929 Vis ikon for arbeidsgiver- og arbeidstakersteg

### DIFF
--- a/app/src/components/oppsummering/SeksjonOppsummering.tsx
+++ b/app/src/components/oppsummering/SeksjonOppsummering.tsx
@@ -1,4 +1,5 @@
-import { FormSummary } from "@navikt/ds-react";
+import { FormSummary, HStack } from "@navikt/ds-react";
+import { ComponentType, SVGProps } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { SeksjonDefinisjonDto } from "~/types/melosysSkjemaTypes.ts";
@@ -9,11 +10,13 @@ interface SeksjonOppsummeringProps {
   seksjon: SeksjonDefinisjonDto;
   data: Record<string, unknown>;
   editHref?: string;
+  icon?: ComponentType<SVGProps<SVGSVGElement>>;
 }
 
 export function SeksjonOppsummering({
   data,
   editHref,
+  icon: Icon,
   seksjon,
 }: SeksjonOppsummeringProps) {
   const { t } = useTranslation();
@@ -27,7 +30,16 @@ export function SeksjonOppsummering({
   return (
     <FormSummary className="mt-8">
       <FormSummary.Header>
-        <FormSummary.Heading level="3">{seksjon.tittel}</FormSummary.Heading>
+        <FormSummary.Heading level="3">
+          {Icon ? (
+            <HStack align="center" gap="space-2">
+              {seksjon.tittel}
+              <Icon aria-hidden fontSize="1.25rem" />
+            </HStack>
+          ) : (
+            seksjon.tittel
+          )}
+        </FormSummary.Heading>
         {editHref && (
           <FormSummary.EditLink href={editHref}>
             {t("felles.endreSvar")}

--- a/app/src/pages/skjema/components/Fremgangsindikator.tsx
+++ b/app/src/pages/skjema/components/Fremgangsindikator.tsx
@@ -36,8 +36,8 @@ export const Fremgangsindikator = ({
         <FremgangsindikatorSteg href={step.key} key={step.key}>
           {step.icon ? (
             <HStack align="center" gap="space-2">
-              <step.icon aria-hidden fontSize="1.25rem" />
               {t(step.title)}
+              <step.icon aria-hidden fontSize="1.25rem" />
             </HStack>
           ) : (
             t(step.title)

--- a/app/src/pages/skjema/components/Fremgangsindikator.tsx
+++ b/app/src/pages/skjema/components/Fremgangsindikator.tsx
@@ -1,5 +1,5 @@
 import { FormProgress, HStack } from "@navikt/ds-react";
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, ReactNode, SVGProps } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { StegKey } from "~/constants/stegKeys.ts";
@@ -10,7 +10,7 @@ export interface StegRekkefolgeItem {
   key: StegKey;
   title: string;
   route: string;
-  icon?: ComponentType<{ "aria-hidden": boolean; fontSize: string }>;
+  icon?: ComponentType<SVGProps<SVGSVGElement>>;
 }
 
 type FremgangsindikatorProps = {

--- a/app/src/pages/skjema/components/Fremgangsindikator.tsx
+++ b/app/src/pages/skjema/components/Fremgangsindikator.tsx
@@ -1,4 +1,5 @@
-import { FormProgress } from "@navikt/ds-react";
+import { FormProgress, HStack } from "@navikt/ds-react";
+import { ComponentType, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { StegKey } from "~/constants/stegKeys.ts";
@@ -9,6 +10,7 @@ export interface StegRekkefolgeItem {
   key: StegKey;
   title: string;
   route: string;
+  icon?: ComponentType<{ "aria-hidden": boolean; fontSize: string }>;
 }
 
 type FremgangsindikatorProps = {
@@ -31,10 +33,35 @@ export const Fremgangsindikator = ({
       totalSteps={stegRekkefolge.length}
     >
       {stegRekkefolge.map((step) => (
-        <FormProgress.Step href={step.key} key={step.key}>
-          {t(step.title)}
-        </FormProgress.Step>
+        <FremgangsindikatorSteg href={step.key} key={step.key}>
+          {step.icon ? (
+            <HStack align="center" gap="space-2">
+              <step.icon aria-hidden fontSize="1.25rem" />
+              {t(step.title)}
+            </HStack>
+          ) : (
+            t(step.title)
+          )}
+        </FremgangsindikatorSteg>
       ))}
     </FormProgress>
   );
 };
+
+type FremgangsindikatorStegProps = Omit<
+  React.ComponentProps<typeof FormProgress.Step>,
+  "children"
+> & { children: ReactNode };
+
+/**
+ * Wrapper rundt FormProgress.Step som aksepterer ReactNode som children.
+ *
+ * FormProgress.Step krever children: string, men vi trenger å kunne
+ * rendre ikoner i tillegg til tekst.
+ */
+function FremgangsindikatorSteg({
+  children,
+  ...rest
+}: FremgangsindikatorStegProps) {
+  return <FormProgress.Step {...rest}>{children as string}</FormProgress.Step>;
+}

--- a/app/src/pages/skjema/components/SkjemaSteg.tsx
+++ b/app/src/pages/skjema/components/SkjemaSteg.tsx
@@ -50,8 +50,8 @@ export function SkjemaSteg({ config, nesteKnapp, children }: SkjemaStegProps) {
       <Heading className="mt-8" level="1" size="large">
         {stepInfo?.icon ? (
           <HStack align="center" gap="space-4">
-            <stepInfo.icon aria-hidden fontSize="1.5rem" />
             {title}
+            <stepInfo.icon aria-hidden fontSize="1.5rem" />
           </HStack>
         ) : (
           title

--- a/app/src/pages/skjema/components/SkjemaSteg.tsx
+++ b/app/src/pages/skjema/components/SkjemaSteg.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeftIcon } from "@navikt/aksel-icons";
-import { Button, Heading } from "@navikt/ds-react";
+import { Button, Heading, HStack } from "@navikt/ds-react";
 import { Link } from "@tanstack/react-router";
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -48,7 +48,14 @@ export function SkjemaSteg({ config, nesteKnapp, children }: SkjemaStegProps) {
         stegRekkefolge={config.stegRekkefolge}
       />
       <Heading className="mt-8" level="1" size="large">
-        {title}
+        {stepInfo?.icon ? (
+          <HStack align="center" gap="space-4">
+            <stepInfo.icon aria-hidden fontSize="1.5rem" />
+            {title}
+          </HStack>
+        ) : (
+          title
+        )}
       </Heading>
       {children}
       <div className="flex gap-4 justify-center mt-8">

--- a/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
+++ b/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
@@ -55,6 +55,7 @@ function OppsummeringStegContent({
           <SeksjonOppsummering
             data={data}
             editHref={editHref}
+            icon={steg?.icon}
             key={seksjonNavn}
             seksjon={seksjon}
           />

--- a/app/src/pages/skjema/stegRekkefølge.ts
+++ b/app/src/pages/skjema/stegRekkefølge.ts
@@ -1,3 +1,5 @@
+import { BriefcaseIcon, PersonRectangleIcon } from "@navikt/aksel-icons";
+
 import { StegKey } from "~/constants/stegKeys.ts";
 import { StegRekkefolgeItem } from "~/pages/skjema/components/Fremgangsindikator.tsx";
 import { Skjemadel } from "~/types/melosysSkjemaTypes.ts";
@@ -6,24 +8,28 @@ const ARBEIDSGIVERENS_VIRKSOMHET_I_NORGE_STEG: StegRekkefolgeItem = {
   key: StegKey.ARBEIDSGIVERENS_VIRKSOMHET_I_NORGE,
   title: "arbeidsgiverensVirksomhetINorgeSteg.tittel",
   route: "/skjema/$id/arbeidsgiverens-virksomhet-i-norge",
+  icon: BriefcaseIcon,
 };
 
 const UTENLANDSOPPDRAGET_STEG: StegRekkefolgeItem = {
   key: StegKey.UTENLANDSOPPDRAGET,
   title: "utenlandsoppdragetSteg.tittel",
   route: "/skjema/$id/utenlandsoppdraget",
+  icon: BriefcaseIcon,
 };
 
 const ARBEIDSSTED_I_UTLANDET_STEG: StegRekkefolgeItem = {
   key: StegKey.ARBEIDSSTED_I_UTLANDET,
   title: "arbeidsstedIUtlandetSteg.tittel",
   route: "/skjema/$id/arbeidssted-i-utlandet",
+  icon: BriefcaseIcon,
 };
 
 const ARBEIDSTAKERENS_LONN_STEG: StegRekkefolgeItem = {
   key: StegKey.ARBEIDSTAKERENS_LONN,
   title: "arbeidstakerenslonnSteg.tittel",
   route: "/skjema/$id/arbeidstakerens-lonn",
+  icon: BriefcaseIcon,
 };
 
 const UTSENDINGSPERIODE_OG_LAND_STEG: StegRekkefolgeItem = {
@@ -36,18 +42,21 @@ const ARBEIDSSITUASJON_STEG: StegRekkefolgeItem = {
   key: StegKey.ARBEIDSSITUASJON,
   title: "arbeidssituasjonSteg.tittel",
   route: "/skjema/$id/arbeidssituasjon",
+  icon: PersonRectangleIcon,
 };
 
 const SKATTEFORHOLD_OG_INNTEKT_STEG: StegRekkefolgeItem = {
   key: StegKey.SKATTEFORHOLD_OG_INNTEKT,
   title: "skatteforholdOgInntektSteg.tittel",
   route: "/skjema/$id/skatteforhold-og-inntekt",
+  icon: PersonRectangleIcon,
 };
 
 const FAMILIEMEDLEMMER_STEG: StegRekkefolgeItem = {
   key: StegKey.FAMILIEMEDLEMMER,
   title: "familiemedlemmerSteg.tittel",
   route: "/skjema/$id/familiemedlemmer",
+  icon: PersonRectangleIcon,
 };
 
 const TILLEGGSOPPLYSNINGER_STEG: StegRekkefolgeItem = {


### PR DESCRIPTION
Viser BriefcaseIcon ved arbeidsgiver-steg og PersonRectangleIcon ved
arbeidstaker-steg, i både fremgangsindikatoren og H1-overskriften.

Når skjema fylles ut for både arbeidsgiver og arbeidstaker er det
vanskelig å se hvilken del man er i. Ikonene tydeliggjør skillet.
[MELOSYS-7929](https://jira.adeo.no/browse/MELOSYS-7929)

- Nytt valgfritt `icon`-felt i `StegRekkefolgeItem`
- `FremgangsindikatorSteg`-wrapper for å støtte ReactNode i FormProgress.Step
- Generelle steg (utsendingsperiode, tilleggsopplysninger, vedlegg, oppsummering) har ikke ikon

## Testing
- [ ] Manuell testing lokalt