### PR TITLE
NOJIRA: Legg til minimumReleaseAge i pnpm-workspace.yml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080


### PR DESCRIPTION
Legger til minimumReleaseAge på 10080 (7 dager) i pnpm-workspace.yaml. Har allerede cooldownperiode på dependabot.