### PR TITLE
NOJIRA Flytt minimumReleaseAge fra pnpm-workspace.yaml til .npmrc per subprosjekt

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,3 +1,4 @@
 @navikt:registry=https://npm.pkg.github.com
 @types:registry=https://registry.npmjs.org
 ignore-scripts=true
+minimum-release-age=10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,0 @@
-minimumReleaseAge: 10080

--- a/server/.npmrc
+++ b/server/.npmrc
@@ -1,3 +1,4 @@
 @navikt:registry=https://npm.pkg.github.com
 @types:registry=https://registry.npmjs.org
 ignore-scripts=true
+minimum-release-age=10080


### PR DESCRIPTION
## Problem

Rot-filen \`pnpm-workspace.yaml\` ble nylig lagt til (#368) med kun én setting:

\`\`\`yaml
minimumReleaseAge: 10080
\`\`\`

Men **uten** en \`packages:\`-array tolker pnpm det som en *tom workspace*. pnpm-kommandoer kjørt i subkataloger (\`app/\` og \`server/\`) matcher da ingen pakker og installerer ingenting.

Dette brøt alle nylige dependabot-PRer som oppdaterer avhengigheter (f.eks. [#358](https://github.com/navikt/melosys-skjema-web/pull/358), [#364](https://github.com/navikt/melosys-skjema-web/pull/364)):

1. Dependabot oppdaterte \`package.json\`
2. CI kjørte \`pnpm install --frozen-lockfile\` i \`server/\` eller \`app/\`
3. pnpm hoppet over alle avhengigheter (0 installert, men 0 feil — \"Done in 458ms\")
4. Etterpå feilet ESLint/TypeScript-stegene med \`eslint: not found\` / \`sh: 1: tsc: not found\`

## Hvorfor ikke bare legge til \`packages:\`?

En naturlig førstetanke er å fikse det slik:

\`\`\`yaml
packages:
  - app
  - server
minimumReleaseAge: 10080
\`\`\`

Men det fungerer ikke. \`app/\` og \`server/\` er **to separate prosjekter** som tilfeldigvis ligger i samme repo — de har hver sin \`package.json\` og hver sin \`pnpm-lock.yaml\`. Hvis vi gjør det til en ekte pnpm-workspace, krever pnpm én felles lockfile i roten, og eksisterende lockfiles matcher ikke. Forsøkt — feiler med lockfile-mismatch.

## Løsning

Fjerner rot \`pnpm-workspace.yaml\` og flytter settingen inn i \`.npmrc\` i hver subkatalog:

\`\`\`
# app/.npmrc og server/.npmrc
...
minimum-release-age=10080
\`\`\`

pnpm respekterer \`minimum-release-age\` i \`.npmrc\` på samme måte som \`minimumReleaseAge\` i \`pnpm-workspace.yaml\`. Ingen funksjonell endring — bare riktig plassering for et prosjekt som ikke er en pnpm-workspace.

## Verifisering

\`pnpm install --frozen-lockfile\` fungerer nå i både \`app/\` og \`server/\` (installerer pakker, ikke bare \"Done in 117ms\").

## Etter merge

Dependabot-PRene som feilet ([#358](https://github.com/navikt/melosys-skjema-web/pull/358), [#364](https://github.com/navikt/melosys-skjema-web/pull/364)) bør rebases (\`@dependabot rebase\`) eller lukkes og gjenopprettes av dependabot — da vil CI passere igjen.