### PR TITLE
MELOSYS-7999 Fiks vite-mode auto-redirect i deployet dev-miljø

### DIFF
--- a/server/src/frontendRoute.ts
+++ b/server/src/frontendRoute.ts
@@ -78,9 +78,11 @@ export function setupStaticRoutes(router: Router) {
       return response.send(await injectViteModeHtml(viteModeHtml));
     }
 
-    // I lokal dev finnes ikke public/index.html — send brukeren til /vite-on
-    // slik at cookien settes og vite-mode aktiveres automatisk.
-    if (config.app.env === "dev" && request.accepts("html")) {
+    // Kun ved lokal kjøring (NAIS_CLUSTER_NAME er ikke satt) finnes ikke
+    // public/index.html — send brukeren til /vite-on slik at cookien settes
+    // og vite-mode aktiveres automatisk. I deployet dev-miljø finnes
+    // public/index.html og vanlig SSR-flyt skal brukes.
+    if (!process.env.NAIS_CLUSTER_NAME && request.accepts("html")) {
       const suffix = request.originalUrl.endsWith("/") ? "vite-on" : "/vite-on";
       return response.redirect(request.originalUrl + suffix);
     }


### PR DESCRIPTION
## Problem
Etter #361 havnet testmiljøet fast i vite-mode — alle HTML-requester ble redirectet til `/<path>/vite-on` og serveren prøvde å laste frontend fra `http://localhost:5173`, som ikke finnes i deployet miljø.

Årsak: sjekken `config.app.env === "dev"` er basert på `NAIS_CLUSTER_NAME`, hvor både `dev-gcp` (testmiljø) og lokalt (ingen verdi) tolkes som `"dev"`. Auto-redirect var ment kun for lokal kjøring.

## Endring
Bytter betingelsen til `!process.env.NAIS_CLUSTER_NAME` — den er kun usatt ved lokal kjøring. I deployet miljø finnes `public/index.html` og vanlig SSR-flyt brukes som før.

## Test plan
- [x] Lokalt: `make local` → redirect til `/vite-on` fungerer fortsatt
- [ ] I testmiljø etter deploy: `/representasjon` skal ikke lenger redirecte og skal servere `public/index.html`