### PR TITLE
8040: Vis utsendingsperiode og land i oppsummering

### DIFF
--- a/app/src/components/oppsummering/dataMapping.test.ts
+++ b/app/src/components/oppsummering/dataMapping.test.ts
@@ -9,6 +9,9 @@ import {
   ARBEIDSTAKERS_DEL,
 } from "~/pages/skjema/types.ts";
 import {
+  ArbeidsstedType,
+  FastEllerVekslendeArbeidssted,
+  LandKode,
   type SkjemaDefinisjonDto,
   Skjemadel,
   type UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto,
@@ -21,7 +24,7 @@ import { resolveSeksjoner } from "./dataMapping.ts";
 const definisjon = SKJEMA_DEFINISJON_A1 as unknown as SkjemaDefinisjonDto;
 
 const utsendingsperiodeOgLand = {
-  utsendelseLand: "SE",
+  utsendelseLand: LandKode.SE,
   utsendelsePeriode: { fraDato: "2026-01-01", tilDato: "2026-12-31" },
 };
 
@@ -53,10 +56,10 @@ const arbeidsgiversDelDto: UtsendtArbeidstakerArbeidsgiversSkjemaDataDto = {
     arbeidstakerErstatterAnnenPerson: false,
   },
   arbeidsstedIUtlandet: {
-    arbeidsstedType: "PA_LAND",
+    arbeidsstedType: ArbeidsstedType.PA_LAND,
     paLand: {
       navnPaVirksomhet: "Test AS",
-      fastEllerVekslendeArbeidssted: "FAST",
+      fastEllerVekslendeArbeidssted: FastEllerVekslendeArbeidssted.FAST,
       erHjemmekontor: false,
     },
   },

--- a/app/src/components/oppsummering/dataMapping.test.ts
+++ b/app/src/components/oppsummering/dataMapping.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import { SKJEMA_DEFINISJON_A1 } from "~/constants/skjemaDefinisjonA1.ts";
+import { StegKey } from "~/constants/stegKeys.ts";
+import { STEG_REKKEFOLGE } from "~/pages/skjema/stegRekkefølge.ts";
+import {
+  ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL,
+  ARBEIDSGIVERS_DEL,
+  ARBEIDSTAKERS_DEL,
+} from "~/pages/skjema/types.ts";
+import {
+  type SkjemaDefinisjonDto,
+  Skjemadel,
+  type UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto,
+  type UtsendtArbeidstakerArbeidsgiversSkjemaDataDto,
+  type UtsendtArbeidstakerArbeidstakersSkjemaDataDto,
+} from "~/types/melosysSkjemaTypes.ts";
+
+import { resolveSeksjoner } from "./dataMapping.ts";
+
+const definisjon = SKJEMA_DEFINISJON_A1 as unknown as SkjemaDefinisjonDto;
+
+const utsendingsperiodeOgLand = {
+  utsendelseLand: "SE",
+  utsendelsePeriode: { fraDato: "2026-01-01", tilDato: "2026-12-31" },
+};
+
+const arbeidstakersDelDto: UtsendtArbeidstakerArbeidstakersSkjemaDataDto = {
+  type: ARBEIDSTAKERS_DEL,
+  utsendingsperiodeOgLand,
+  arbeidssituasjon: {
+    harVaertEllerSkalVaereILonnetArbeidFoerUtsending: true,
+    skalJobbeForFlereVirksomheter: false,
+  },
+  skatteforholdOgInntekt: {
+    erSkattepliktigTilNorgeIHeleutsendingsperioden: true,
+    mottarPengestotteFraAnnetEosLandEllerSveits: false,
+  },
+  familiemedlemmer: { skalHaMedFamiliemedlemmer: false, familiemedlemmer: [] },
+  tilleggsopplysninger: { harFlereOpplysningerTilSoknaden: false },
+};
+
+const arbeidsgiversDelDto: UtsendtArbeidstakerArbeidsgiversSkjemaDataDto = {
+  type: ARBEIDSGIVERS_DEL,
+  utsendingsperiodeOgLand,
+  arbeidsgiverensVirksomhetINorge: {
+    erArbeidsgiverenOffentligVirksomhet: true,
+  },
+  utenlandsoppdraget: {
+    arbeidsgiverHarOppdragILandet: true,
+    arbeidstakerBleAnsattForUtenlandsoppdraget: false,
+    arbeidstakerForblirAnsattIHelePerioden: true,
+    arbeidstakerErstatterAnnenPerson: false,
+  },
+  arbeidsstedIUtlandet: {
+    arbeidsstedType: "PA_LAND",
+    paLand: {
+      navnPaVirksomhet: "Test AS",
+      fastEllerVekslendeArbeidssted: "FAST",
+      erHjemmekontor: false,
+    },
+  },
+  arbeidstakerensLonn: {
+    arbeidsgiverBetalerAllLonnOgNaturaytelserIUtsendingsperioden: true,
+  },
+  tilleggsopplysninger: { harFlereOpplysningerTilSoknaden: false },
+};
+
+const kombinertDto: UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto =
+  {
+    type: ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL,
+    utsendingsperiodeOgLand,
+    tilleggsopplysninger: { harFlereOpplysningerTilSoknaden: false },
+    arbeidsgiversData: {
+      arbeidsgiverensVirksomhetINorge:
+        arbeidsgiversDelDto.arbeidsgiverensVirksomhetINorge,
+      utenlandsoppdraget: arbeidsgiversDelDto.utenlandsoppdraget,
+      arbeidsstedIUtlandet: arbeidsgiversDelDto.arbeidsstedIUtlandet,
+      arbeidstakerensLonn: arbeidsgiversDelDto.arbeidstakerensLonn,
+    },
+    arbeidstakersData: {
+      arbeidssituasjon: arbeidstakersDelDto.arbeidssituasjon,
+      skatteforholdOgInntekt: arbeidstakersDelDto.skatteforholdOgInntekt,
+      familiemedlemmer: arbeidstakersDelDto.familiemedlemmer,
+    },
+  };
+
+describe("resolveSeksjoner", () => {
+  it("arbeidstakers del inneholder alle forventede seksjoner med utsendingsperiodeOgLand øverst", () => {
+    const seksjoner = resolveSeksjoner(arbeidstakersDelDto, definisjon);
+    expect(seksjoner.map((s) => s.seksjonNavn)).toEqual([
+      "utsendingsperiodeOgLand",
+      "arbeidssituasjon",
+      "skatteforholdOgInntekt",
+      "familiemedlemmer",
+      "tilleggsopplysningerArbeidstaker",
+    ]);
+  });
+
+  it("arbeidsgivers del inneholder alle forventede seksjoner med utsendingsperiodeOgLand øverst", () => {
+    const seksjoner = resolveSeksjoner(arbeidsgiversDelDto, definisjon);
+    expect(seksjoner.map((s) => s.seksjonNavn)).toEqual([
+      "utsendingsperiodeOgLand",
+      "arbeidsgiverensVirksomhetINorge",
+      "utenlandsoppdragetArbeidsgiver",
+      "arbeidsstedIUtlandet",
+      "arbeidsstedPaLand",
+      "arbeidstakerensLonn",
+      "tilleggsopplysningerArbeidsgiver",
+    ]);
+  });
+
+  it("kombinert flyt har utsendingsperiodeOgLand øverst og ingen duplikater", () => {
+    const seksjoner = resolveSeksjoner(kombinertDto, definisjon);
+    const navn = seksjoner.map((s) => s.seksjonNavn);
+
+    expect(navn[0]).toBe("utsendingsperiodeOgLand");
+    expect(new Set(navn).size).toBe(navn.length);
+  });
+
+  // Dekningstest: fanger nye steg som blir lagt til uten oppdatering av dataMapping.
+  // Hvis noen legger til et nytt content-steg i STEG_REKKEFOLGE med en tilhørende
+  // seksjonsdefinisjon, må det også få minst én entry i resolveSeksjoner-output.
+  describe("hvert content-steg har minst én seksjon i oppsummeringen", () => {
+    const META_STEG = new Set<string>([StegKey.VEDLEGG, StegKey.OPPSUMMERING]);
+
+    const cases: Array<{
+      navn: string;
+      skjemadel: Skjemadel;
+      dto:
+        | UtsendtArbeidstakerArbeidstakersSkjemaDataDto
+        | UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
+        | UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto;
+    }> = [
+      {
+        navn: "arbeidstakers del",
+        skjemadel: Skjemadel.ARBEIDSTAKERS_DEL,
+        dto: arbeidstakersDelDto,
+      },
+      {
+        navn: "arbeidsgivers del",
+        skjemadel: Skjemadel.ARBEIDSGIVERS_DEL,
+        dto: arbeidsgiversDelDto,
+      },
+      {
+        navn: "kombinert",
+        skjemadel: Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL,
+        dto: kombinertDto,
+      },
+    ];
+
+    it.each(cases)("$navn dekker alle content-steg", ({ skjemadel, dto }) => {
+      const stegRekkefolge = STEG_REKKEFOLGE[skjemadel];
+      const contentSteg = stegRekkefolge
+        .map((s) => s.key)
+        .filter((key) => !META_STEG.has(key));
+
+      const seksjoner = resolveSeksjoner(dto, definisjon);
+      const dekkede = new Set(seksjoner.map((s) => s.stegKey));
+
+      const manglende = contentSteg.filter((key) => !dekkede.has(key));
+      expect(
+        manglende,
+        `Steg uten seksjon i oppsummeringen: ${manglende.join(", ")}`,
+      ).toEqual([]);
+    });
+  });
+});

--- a/app/src/components/oppsummering/dataMapping.ts
+++ b/app/src/components/oppsummering/dataMapping.ts
@@ -11,6 +11,7 @@ import type {
   PaLandDto,
   SeksjonDefinisjonDto,
   SkjemaDefinisjonDto,
+  UtsendingsperiodeOgLandDto,
   UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto,
   UtsendtArbeidstakerArbeidsgiversSkjemaDataDto,
   UtsendtArbeidstakerArbeidstakersSkjemaDataDto,
@@ -67,20 +68,26 @@ interface SeksjonMappingEntry {
   data: Record<string, unknown> | undefined;
 }
 
+function utsendingsperiodeOgLandEntry(
+  utsendingsperiodeOgLand?: UtsendingsperiodeOgLandDto,
+): SeksjonMappingEntry {
+  return {
+    seksjonNavn: "utsendingsperiodeOgLand",
+    stegKey: StegKey.UTSENDINGSPERIODE_OG_LAND,
+    data: utsendingsperiodeOgLand
+      ? {
+          utsendelseLand: utsendingsperiodeOgLand.utsendelseLand,
+          utsendelsePeriode: utsendingsperiodeOgLand.utsendelsePeriode,
+        }
+      : undefined,
+  };
+}
+
 function mapArbeidstakerSeksjoner(
   dto: UtsendtArbeidstakerArbeidstakersSkjemaDataDto,
 ): SeksjonMappingEntry[] {
   return [
-    {
-      seksjonNavn: "utsendingsperiodeOgLand",
-      stegKey: StegKey.UTSENDINGSPERIODE_OG_LAND,
-      data: dto.utsendingsperiodeOgLand
-        ? {
-            utsendelseLand: dto.utsendingsperiodeOgLand.utsendelseLand,
-            utsendelsePeriode: dto.utsendingsperiodeOgLand.utsendelsePeriode,
-          }
-        : undefined,
-    },
+    utsendingsperiodeOgLandEntry(dto.utsendingsperiodeOgLand),
     {
       seksjonNavn: "arbeidssituasjon",
       stegKey: StegKey.ARBEIDSSITUASJON,
@@ -117,6 +124,7 @@ function mapArbeidsgiverSeksjoner(
   dto: UtsendtArbeidstakerArbeidsgiversSkjemaDataDto,
 ): SeksjonMappingEntry[] {
   return [
+    utsendingsperiodeOgLandEntry(dto.utsendingsperiodeOgLand),
     {
       seksjonNavn: "arbeidsgiverensVirksomhetINorge",
       stegKey: StegKey.ARBEIDSGIVERENS_VIRKSOMHET_I_NORGE,
@@ -185,13 +193,13 @@ function mapCombinedSeksjoner(
   dto: UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto,
 ): SeksjonMappingEntry[] {
   return [
+    utsendingsperiodeOgLandEntry(dto.utsendingsperiodeOgLand),
     ...mapArbeidsgiverSeksjoner({
       ...dto.arbeidsgiversData,
       tilleggsopplysninger: dto.tilleggsopplysninger,
     } as UtsendtArbeidstakerArbeidsgiversSkjemaDataDto),
     ...mapArbeidstakerSeksjoner({
       ...dto.arbeidstakersData,
-      utsendingsperiodeOgLand: dto.utsendingsperiodeOgLand,
       tilleggsopplysninger: dto.tilleggsopplysninger,
     } as UtsendtArbeidstakerArbeidstakersSkjemaDataDto),
   ];

--- a/app/src/pages/skjema/innsendt/InnsendtSkjemaPage.tsx
+++ b/app/src/pages/skjema/innsendt/InnsendtSkjemaPage.tsx
@@ -111,7 +111,6 @@ function getArbeidsgiverData(
     return {
       ...combined.arbeidsgiversData,
       tilleggsopplysninger: combined.tilleggsopplysninger,
-      utsendingsperiodeOgLand: combined.utsendingsperiodeOgLand,
       type: ARBEIDSGIVERS_DEL,
     } as UtsendtArbeidstakerArbeidsgiversSkjemaDataDto;
   }


### PR DESCRIPTION
Manglet i oppsummeringssteg (arbeidsgiver-only) og var feilplassert i kombinert flyt. Vises nå som felles seksjon øverst.