### PR TITLE
8055: Vis arbeidstaker og arbeidsgiver øverst i oppsummering

### DIFF
--- a/app/src/components/oppsummering/ArbeidstakerOgArbeidsgiverOppsummering.tsx
+++ b/app/src/components/oppsummering/ArbeidstakerOgArbeidsgiverOppsummering.tsx
@@ -1,0 +1,89 @@
+import { FormSummary, HStack } from "@navikt/ds-react";
+import { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { StegIkon } from "~/pages/skjema/components/Fremgangsindikator.tsx";
+import {
+  ARBEIDSGIVER_IKON,
+  ARBEIDSTAKER_IKON,
+} from "~/pages/skjema/stegRekkefølge.ts";
+import type { UtsendtArbeidstakerSkjemaDto } from "~/types/melosysSkjemaTypes.ts";
+
+interface ArbeidstakerOgArbeidsgiverOppsummeringProps {
+  skjema: UtsendtArbeidstakerSkjemaDto;
+}
+
+export function ArbeidstakerOgArbeidsgiverOppsummering({
+  skjema,
+}: ArbeidstakerOgArbeidsgiverOppsummeringProps) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Oppsummeringsboks
+        ikon={ARBEIDSTAKER_IKON}
+        tittel={t("oversiktFelles.arbeidstakerTittel")}
+      >
+        <FormSummary.Answer>
+          <FormSummary.Label>{t("felles.navn")}</FormSummary.Label>
+          <FormSummary.Value>
+            {skjema.metadata.arbeidstakerNavn}
+          </FormSummary.Value>
+        </FormSummary.Answer>
+        <FormSummary.Answer>
+          <FormSummary.Label>
+            {t("oversiktFelles.arbeidstakerFnrLabel")}
+          </FormSummary.Label>
+          <FormSummary.Value>{skjema.fnr}</FormSummary.Value>
+        </FormSummary.Answer>
+      </Oppsummeringsboks>
+
+      <Oppsummeringsboks
+        ikon={ARBEIDSGIVER_IKON}
+        tittel={t("oversiktFelles.arbeidsgiverTittel")}
+      >
+        <FormSummary.Answer>
+          <FormSummary.Label>{t("felles.virksomhetsnavn")}</FormSummary.Label>
+          <FormSummary.Value>
+            {skjema.metadata.arbeidsgiverNavn}
+          </FormSummary.Value>
+        </FormSummary.Answer>
+        <FormSummary.Answer>
+          <FormSummary.Label>
+            {t("felles.organisasjonsnummer")}
+          </FormSummary.Label>
+          <FormSummary.Value>{skjema.orgnr}</FormSummary.Value>
+        </FormSummary.Answer>
+      </Oppsummeringsboks>
+    </>
+  );
+}
+
+function Oppsummeringsboks({
+  ikon,
+  tittel,
+  children,
+}: {
+  ikon: StegIkon;
+  tittel: string;
+  children: ReactNode;
+}) {
+  const { t } = useTranslation();
+  return (
+    <FormSummary className="mt-8">
+      <FormSummary.Header>
+        <FormSummary.Heading level="3">
+          <HStack as="span" align="center" gap="space-8">
+            {tittel}
+            <ikon.icon
+              aria-label={t(ikon.ariaLabel)}
+              role="img"
+              fontSize="1.5rem"
+            />
+          </HStack>
+        </FormSummary.Heading>
+      </FormSummary.Header>
+      <FormSummary.Answers>{children}</FormSummary.Answers>
+    </FormSummary>
+  );
+}

--- a/app/src/components/oppsummering/ArbeidstakerOgArbeidsgiverOppsummering.tsx
+++ b/app/src/components/oppsummering/ArbeidstakerOgArbeidsgiverOppsummering.tsx
@@ -9,12 +9,17 @@ import {
 } from "~/pages/skjema/stegRekkefølge.ts";
 import type { UtsendtArbeidstakerSkjemaDto } from "~/types/melosysSkjemaTypes.ts";
 
+type HeadingLevel = "2" | "3" | "4" | "5" | "6";
+
 interface ArbeidstakerOgArbeidsgiverOppsummeringProps {
   skjema: UtsendtArbeidstakerSkjemaDto;
+  /** Heading-nivå for boks-headingene. Velges ut fra hierarkiet rundt komponenten. */
+  headingLevel?: HeadingLevel;
 }
 
 export function ArbeidstakerOgArbeidsgiverOppsummering({
   skjema,
+  headingLevel = "3",
 }: ArbeidstakerOgArbeidsgiverOppsummeringProps) {
   const { t } = useTranslation();
 
@@ -23,6 +28,7 @@ export function ArbeidstakerOgArbeidsgiverOppsummering({
       <Oppsummeringsboks
         ikon={ARBEIDSTAKER_IKON}
         tittel={t("oversiktFelles.arbeidstakerTittel")}
+        headingLevel={headingLevel}
       >
         <FormSummary.Answer>
           <FormSummary.Label>{t("felles.navn")}</FormSummary.Label>
@@ -41,6 +47,7 @@ export function ArbeidstakerOgArbeidsgiverOppsummering({
       <Oppsummeringsboks
         ikon={ARBEIDSGIVER_IKON}
         tittel={t("oversiktFelles.arbeidsgiverTittel")}
+        headingLevel={headingLevel}
       >
         <FormSummary.Answer>
           <FormSummary.Label>{t("felles.virksomhetsnavn")}</FormSummary.Label>
@@ -62,17 +69,19 @@ export function ArbeidstakerOgArbeidsgiverOppsummering({
 function Oppsummeringsboks({
   ikon,
   tittel,
+  headingLevel,
   children,
 }: {
   ikon: StegIkon;
   tittel: string;
+  headingLevel: HeadingLevel;
   children: ReactNode;
 }) {
   const { t } = useTranslation();
   return (
     <FormSummary className="mt-8">
       <FormSummary.Header>
-        <FormSummary.Heading level="3">
+        <FormSummary.Heading level={headingLevel}>
           <HStack as="span" align="center" gap="space-8">
             {tittel}
             <ikon.icon

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -45,7 +45,7 @@ export const en = {
       stegGjelderArbeidsgiver: "This step applies to the employer",
       stegGjelderArbeidstaker: "This step applies to the employee",
       virksomhetsnavn: "Company name",
-      organisasjonsnummer: "Organisation number",
+      organisasjonsnummer: "Organization number",
     },
     skjemaVeiledning: {
       hei: "Hello",

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -44,6 +44,8 @@ export const en = {
         "Invalid national identity number or D-number",
       stegGjelderArbeidsgiver: "This step applies to the employer",
       stegGjelderArbeidstaker: "This step applies to the employee",
+      virksomhetsnavn: "Company name",
+      organisasjonsnummer: "Organisation number",
     },
     skjemaVeiledning: {
       hei: "Hello",

--- a/app/src/i18n/nb.ts
+++ b/app/src/i18n/nb.ts
@@ -43,6 +43,8 @@ export const nb = {
       ugyldigFodselsnummerEllerDnummer: "Ugyldig fødselsnummer eller D-nummer",
       stegGjelderArbeidsgiver: "Dette steget gjelder arbeidsgiver",
       stegGjelderArbeidstaker: "Dette steget gjelder arbeidstaker",
+      virksomhetsnavn: "Virksomhetsnavn",
+      organisasjonsnummer: "Organisasjonsnummer",
     },
     periode: {
       fraDato: "Fra dato",

--- a/app/src/pages/skjema/innsendt/InnsendtSkjemaPage.tsx
+++ b/app/src/pages/skjema/innsendt/InnsendtSkjemaPage.tsx
@@ -13,6 +13,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 
+import { ArbeidstakerOgArbeidsgiverOppsummering } from "~/components/oppsummering/ArbeidstakerOgArbeidsgiverOppsummering.tsx";
 import { SeksjonOppsummering } from "~/components/oppsummering/SeksjonOppsummering.tsx";
 import { VedleggOppsummering } from "~/components/oppsummering/VedleggOppsummering.tsx";
 import {
@@ -156,6 +157,8 @@ function InnsendtSkjemaPageContent({
         <Tag variant="info">{response.referanseId}</Tag>
         <BodyShort>{formatDato(response.innsendtDato)}</BodyShort>
       </HStack>
+
+      <ArbeidstakerOgArbeidsgiverOppsummering skjema={skjema} />
 
       {arbeidstakerSeksjoner.length > 0 && (
         <VStack gap="space-16">

--- a/app/src/pages/skjema/innsendt/InnsendtSkjemaPage.tsx
+++ b/app/src/pages/skjema/innsendt/InnsendtSkjemaPage.tsx
@@ -158,7 +158,10 @@ function InnsendtSkjemaPageContent({
         <BodyShort>{formatDato(response.innsendtDato)}</BodyShort>
       </HStack>
 
-      <ArbeidstakerOgArbeidsgiverOppsummering skjema={skjema} />
+      <ArbeidstakerOgArbeidsgiverOppsummering
+        skjema={skjema}
+        headingLevel="2"
+      />
 
       {arbeidstakerSeksjoner.length > 0 && (
         <VStack gap="space-16">

--- a/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
+++ b/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
@@ -2,6 +2,7 @@ import { Alert } from "@navikt/ds-react";
 import { Fragment } from "react";
 import { useTranslation } from "react-i18next";
 
+import { ArbeidstakerOgArbeidsgiverOppsummering } from "~/components/oppsummering/ArbeidstakerOgArbeidsgiverOppsummering.tsx";
 import { resolveSeksjoner } from "~/components/oppsummering/dataMapping.ts";
 import { SeksjonOppsummering } from "~/components/oppsummering/SeksjonOppsummering.tsx";
 import { VedleggOppsummering } from "~/components/oppsummering/VedleggOppsummering.tsx";
@@ -49,6 +50,7 @@ function OppsummeringStegContent({
       }}
       nesteKnapp={<SendInnSkjemaKnapp skjemaId={skjema.id} />}
     >
+      <ArbeidstakerOgArbeidsgiverOppsummering skjema={skjema} />
       {seksjoner.map(({ seksjonNavn, seksjon, data, stegKey }) => {
         const steg = stegRekkefolge.find((s) => s.key === stegKey);
         const editHref = steg?.route.replace("$id", skjema.id) ?? "";

--- a/app/src/pages/skjema/stegRekkefølge.ts
+++ b/app/src/pages/skjema/stegRekkefølge.ts
@@ -7,12 +7,12 @@ import {
 } from "~/pages/skjema/components/Fremgangsindikator.tsx";
 import { Skjemadel } from "~/types/melosysSkjemaTypes.ts";
 
-const ARBEIDSGIVER_IKON: StegIkon = {
+export const ARBEIDSGIVER_IKON: StegIkon = {
   icon: BriefcaseIcon,
   ariaLabel: "felles.stegGjelderArbeidsgiver",
 };
 
-const ARBEIDSTAKER_IKON: StegIkon = {
+export const ARBEIDSTAKER_IKON: StegIkon = {
   icon: PersonRectangleIcon,
   ariaLabel: "felles.stegGjelderArbeidstaker",
 };

--- a/app/src/types/melosysSkjemaTypes.ts
+++ b/app/src/types/melosysSkjemaTypes.ts
@@ -128,10 +128,18 @@ export enum VedleggFiltype {
 }
 
 export interface FeltDefinisjonDto {
-  hjelpetekst?: string;
-  pakrevd: boolean;
   label: string;
+  pakrevd: boolean;
+  hjelpetekst?: string;
   type: string;
+}
+
+export interface RegistrerSaksnummerRequest {
+  /**
+   * @minLength 0
+   * @maxLength 99
+   */
+  saksnummer: string;
 }
 
 export interface VedleggDto {
@@ -159,34 +167,50 @@ export interface UtsendingsperiodeOgLandDto {
 
 export type AnnenPersonMetadata = UtilRequiredKeys<
   UtsendtArbeidstakerMetadata,
-  | "representasjonstype"
+  | "arbeidstakerNavn"
   | "skjemadel"
-  | "juridiskEnhetOrgnr"
   | "arbeidsgiverNavn"
+  | "juridiskEnhetOrgnr"
+  | "representasjonstype"
   | "metadatatype"
 > & {
   fullmektigFnr: string;
+  /** @format uuid */
+  kobletSkjemaId?: string;
+  /** @format uuid */
+  erstatterSkjemaId?: string;
 };
 
 export type ArbeidsgiverMedFullmaktMetadata = UtilRequiredKeys<
   UtsendtArbeidstakerMetadata,
-  | "representasjonstype"
+  | "arbeidstakerNavn"
   | "skjemadel"
-  | "juridiskEnhetOrgnr"
   | "arbeidsgiverNavn"
+  | "juridiskEnhetOrgnr"
+  | "representasjonstype"
   | "metadatatype"
 > & {
   fullmektigFnr: string;
+  /** @format uuid */
+  kobletSkjemaId?: string;
+  /** @format uuid */
+  erstatterSkjemaId?: string;
 };
 
 export type ArbeidsgiverMetadata = UtilRequiredKeys<
   UtsendtArbeidstakerMetadata,
-  | "representasjonstype"
+  | "arbeidstakerNavn"
   | "skjemadel"
-  | "juridiskEnhetOrgnr"
   | "arbeidsgiverNavn"
+  | "juridiskEnhetOrgnr"
+  | "representasjonstype"
   | "metadatatype"
->;
+> & {
+  /** @format uuid */
+  kobletSkjemaId?: string;
+  /** @format uuid */
+  erstatterSkjemaId?: string;
+};
 
 export interface ArbeidsgiverensVirksomhetINorgeDto {
   erArbeidsgiverenOffentligVirksomhet: boolean;
@@ -229,12 +253,18 @@ export interface ArbeidstakersData {
 
 export type DegSelvMetadata = UtilRequiredKeys<
   UtsendtArbeidstakerMetadata,
-  | "representasjonstype"
+  | "arbeidstakerNavn"
   | "skjemadel"
-  | "juridiskEnhetOrgnr"
   | "arbeidsgiverNavn"
+  | "juridiskEnhetOrgnr"
+  | "representasjonstype"
   | "metadatatype"
->;
+> & {
+  /** @format uuid */
+  kobletSkjemaId?: string;
+  /** @format uuid */
+  erstatterSkjemaId?: string;
+};
 
 export interface Familiemedlem {
   fornavn: string;
@@ -306,24 +336,34 @@ export interface PaSkipDto {
 
 export type RadgiverMedFullmaktMetadata = UtilRequiredKeys<
   UtsendtArbeidstakerMetadata,
-  | "representasjonstype"
+  | "arbeidstakerNavn"
   | "skjemadel"
-  | "juridiskEnhetOrgnr"
   | "arbeidsgiverNavn"
+  | "juridiskEnhetOrgnr"
+  | "representasjonstype"
   | "metadatatype"
 > & {
   fullmektigFnr: string;
+  /** @format uuid */
+  kobletSkjemaId?: string;
+  /** @format uuid */
+  erstatterSkjemaId?: string;
   radgiverfirma: RadgiverfirmaInfo;
 };
 
 export type RadgiverMetadata = UtilRequiredKeys<
   UtsendtArbeidstakerMetadata,
-  | "representasjonstype"
+  | "arbeidstakerNavn"
   | "skjemadel"
-  | "juridiskEnhetOrgnr"
   | "arbeidsgiverNavn"
+  | "juridiskEnhetOrgnr"
+  | "representasjonstype"
   | "metadatatype"
 > & {
+  /** @format uuid */
+  kobletSkjemaId?: string;
+  /** @format uuid */
+  erstatterSkjemaId?: string;
   radgiverfirma: RadgiverfirmaInfo;
 };
 
@@ -385,6 +425,8 @@ export type UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto =
   UtilRequiredKeys<UtsendtArbeidstakerSkjemaData, "type"> & {
     arbeidsgiversData: ArbeidsgiversData;
     arbeidstakersData: ArbeidstakersData;
+    utsendingsperiodeOgLand?: UtsendingsperiodeOgLandDto;
+    tilleggsopplysninger?: TilleggsopplysningerDto;
   };
 
 export type UtsendtArbeidstakerArbeidsgiversSkjemaDataDto = UtilRequiredKeys<
@@ -395,26 +437,31 @@ export type UtsendtArbeidstakerArbeidsgiversSkjemaDataDto = UtilRequiredKeys<
   utenlandsoppdraget?: UtenlandsoppdragetDto;
   arbeidstakerensLonn?: ArbeidstakerensLonnDto;
   arbeidsstedIUtlandet?: ArbeidsstedIUtlandetDto;
+  utsendingsperiodeOgLand?: UtsendingsperiodeOgLandDto;
+  tilleggsopplysninger?: TilleggsopplysningerDto;
 };
 
 export type UtsendtArbeidstakerArbeidstakersSkjemaDataDto = UtilRequiredKeys<
   UtsendtArbeidstakerSkjemaData,
   "type"
 > & {
+  utsendingsperiodeOgLand?: UtsendingsperiodeOgLandDto;
   arbeidssituasjon?: ArbeidssituasjonDto;
   skatteforholdOgInntekt?: SkatteforholdOgInntektDto;
   familiemedlemmer?: FamiliemedlemmerDto;
+  tilleggsopplysninger?: TilleggsopplysningerDto;
 };
 
 export interface UtsendtArbeidstakerMetadata {
-  representasjonstype: Representasjonstype;
   /** @format uuid */
   erstatterSkjemaId?: string;
+  arbeidstakerNavn: string;
   skjemadel: Skjemadel;
-  juridiskEnhetOrgnr: string;
   arbeidsgiverNavn: string;
+  juridiskEnhetOrgnr: string;
   /** @format uuid */
   kobletSkjemaId?: string;
+  representasjonstype: Representasjonstype;
   metadatatype: string;
 }
 
@@ -506,7 +553,7 @@ export interface InnsendtSoknadOversiktDto {
   referanseId?: string;
   arbeidsgiverNavn?: string;
   arbeidsgiverOrgnr: string;
-  arbeidstakerNavn?: string;
+  arbeidstakerNavn: string;
   arbeidstakerFnrMaskert?: string;
   /** @format date */
   arbeidstakerFodselsdato: string;
@@ -558,21 +605,26 @@ export interface AlternativDefinisjonDto {
 
 export type BooleanFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "pakrevd" | "label"
+  "label" | "pakrevd"
 > & {
+  hjelpetekst?: string;
   jaLabel: string;
   neiLabel: string;
 };
 
 export type CountrySelectFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "pakrevd" | "label"
->;
+  "label" | "pakrevd"
+> & {
+  hjelpetekst?: string;
+};
 
 export type DateFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "pakrevd" | "label"
->;
+  "label" | "pakrevd"
+> & {
+  hjelpetekst?: string;
+};
 
 /** Innsendt søknad med skjemadefinisjon for korrekt visning */
 export interface InnsendtSkjemaResponse {
@@ -614,8 +666,9 @@ export interface InnsendtSkjemaResponse {
 
 export type ListeFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "pakrevd" | "label"
+  "label" | "pakrevd"
 > & {
+  hjelpetekst?: string;
   leggTilLabel: string;
   fjernLabel: string;
   tomListeMelding?: string;
@@ -634,8 +687,9 @@ export type ListeFeltDefinisjon = UtilRequiredKeys<
 
 export type PeriodeFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "pakrevd" | "label"
+  "label" | "pakrevd"
 > & {
+  hjelpetekst?: string;
   fraDatoLabel: string;
   tilDatoLabel: string;
 };
@@ -658,8 +712,9 @@ export interface SeksjonDefinisjonDto {
 
 export type SelectFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "pakrevd" | "label"
+  "label" | "pakrevd"
 > & {
+  hjelpetekst?: string;
   alternativer: AlternativDefinisjonDto[];
 };
 
@@ -671,13 +726,16 @@ export interface SkjemaDefinisjonDto {
 
 export type TextFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "pakrevd" | "label"
->;
+  "label" | "pakrevd"
+> & {
+  hjelpetekst?: string;
+};
 
 export type TextareaFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "pakrevd" | "label"
+  "label" | "pakrevd"
 > & {
+  hjelpetekst?: string;
   /** @format int32 */
   maxLength?: number;
 };
@@ -693,7 +751,7 @@ export interface UtkastOversiktDto {
   id: string;
   arbeidsgiverNavn?: string;
   arbeidsgiverOrgnr?: string;
-  arbeidstakerNavn?: string;
+  arbeidstakerNavn: string;
   arbeidstakerFnrMaskert?: string;
   /** @format date-time */
   opprettetDato: string;

--- a/app/src/types/melosysSkjemaTypes.ts
+++ b/app/src/types/melosysSkjemaTypes.ts
@@ -128,9 +128,9 @@ export enum VedleggFiltype {
 }
 
 export interface FeltDefinisjonDto {
-  label: string;
-  pakrevd: boolean;
   hjelpetekst?: string;
+  pakrevd: boolean;
+  label: string;
   type: string;
 }
 
@@ -167,11 +167,11 @@ export interface UtsendingsperiodeOgLandDto {
 
 export type AnnenPersonMetadata = UtilRequiredKeys<
   UtsendtArbeidstakerMetadata,
-  | "arbeidstakerNavn"
   | "skjemadel"
-  | "arbeidsgiverNavn"
   | "juridiskEnhetOrgnr"
+  | "arbeidsgiverNavn"
   | "representasjonstype"
+  | "arbeidstakerNavn"
   | "metadatatype"
 > & {
   fullmektigFnr: string;
@@ -183,11 +183,11 @@ export type AnnenPersonMetadata = UtilRequiredKeys<
 
 export type ArbeidsgiverMedFullmaktMetadata = UtilRequiredKeys<
   UtsendtArbeidstakerMetadata,
-  | "arbeidstakerNavn"
   | "skjemadel"
-  | "arbeidsgiverNavn"
   | "juridiskEnhetOrgnr"
+  | "arbeidsgiverNavn"
   | "representasjonstype"
+  | "arbeidstakerNavn"
   | "metadatatype"
 > & {
   fullmektigFnr: string;
@@ -199,11 +199,11 @@ export type ArbeidsgiverMedFullmaktMetadata = UtilRequiredKeys<
 
 export type ArbeidsgiverMetadata = UtilRequiredKeys<
   UtsendtArbeidstakerMetadata,
-  | "arbeidstakerNavn"
   | "skjemadel"
-  | "arbeidsgiverNavn"
   | "juridiskEnhetOrgnr"
+  | "arbeidsgiverNavn"
   | "representasjonstype"
+  | "arbeidstakerNavn"
   | "metadatatype"
 > & {
   /** @format uuid */
@@ -253,11 +253,11 @@ export interface ArbeidstakersData {
 
 export type DegSelvMetadata = UtilRequiredKeys<
   UtsendtArbeidstakerMetadata,
-  | "arbeidstakerNavn"
   | "skjemadel"
-  | "arbeidsgiverNavn"
   | "juridiskEnhetOrgnr"
+  | "arbeidsgiverNavn"
   | "representasjonstype"
+  | "arbeidstakerNavn"
   | "metadatatype"
 > & {
   /** @format uuid */
@@ -336,11 +336,11 @@ export interface PaSkipDto {
 
 export type RadgiverMedFullmaktMetadata = UtilRequiredKeys<
   UtsendtArbeidstakerMetadata,
-  | "arbeidstakerNavn"
   | "skjemadel"
-  | "arbeidsgiverNavn"
   | "juridiskEnhetOrgnr"
+  | "arbeidsgiverNavn"
   | "representasjonstype"
+  | "arbeidstakerNavn"
   | "metadatatype"
 > & {
   fullmektigFnr: string;
@@ -353,11 +353,11 @@ export type RadgiverMedFullmaktMetadata = UtilRequiredKeys<
 
 export type RadgiverMetadata = UtilRequiredKeys<
   UtsendtArbeidstakerMetadata,
-  | "arbeidstakerNavn"
   | "skjemadel"
-  | "arbeidsgiverNavn"
   | "juridiskEnhetOrgnr"
+  | "arbeidsgiverNavn"
   | "representasjonstype"
+  | "arbeidstakerNavn"
   | "metadatatype"
 > & {
   /** @format uuid */
@@ -453,21 +453,21 @@ export type UtsendtArbeidstakerArbeidstakersSkjemaDataDto = UtilRequiredKeys<
 };
 
 export interface UtsendtArbeidstakerMetadata {
+  skjemadel: Skjemadel;
+  juridiskEnhetOrgnr: string;
+  arbeidsgiverNavn: string;
+  representasjonstype: Representasjonstype;
+  /** @format uuid */
+  kobletSkjemaId?: string;
   /** @format uuid */
   erstatterSkjemaId?: string;
   arbeidstakerNavn: string;
-  skjemadel: Skjemadel;
-  arbeidsgiverNavn: string;
-  juridiskEnhetOrgnr: string;
-  /** @format uuid */
-  kobletSkjemaId?: string;
-  representasjonstype: Representasjonstype;
   metadatatype: string;
 }
 
 export interface UtsendtArbeidstakerSkjemaData {
-  utsendingsperiodeOgLand?: UtsendingsperiodeOgLandDto;
   tilleggsopplysninger?: TilleggsopplysningerDto;
+  utsendingsperiodeOgLand?: UtsendingsperiodeOgLandDto;
   type: string;
 }
 
@@ -605,7 +605,7 @@ export interface AlternativDefinisjonDto {
 
 export type BooleanFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "label" | "pakrevd"
+  "pakrevd" | "label"
 > & {
   hjelpetekst?: string;
   jaLabel: string;
@@ -614,14 +614,14 @@ export type BooleanFeltDefinisjon = UtilRequiredKeys<
 
 export type CountrySelectFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "label" | "pakrevd"
+  "pakrevd" | "label"
 > & {
   hjelpetekst?: string;
 };
 
 export type DateFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "label" | "pakrevd"
+  "pakrevd" | "label"
 > & {
   hjelpetekst?: string;
 };
@@ -666,7 +666,7 @@ export interface InnsendtSkjemaResponse {
 
 export type ListeFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "label" | "pakrevd"
+  "pakrevd" | "label"
 > & {
   hjelpetekst?: string;
   leggTilLabel: string;
@@ -687,7 +687,7 @@ export type ListeFeltDefinisjon = UtilRequiredKeys<
 
 export type PeriodeFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "label" | "pakrevd"
+  "pakrevd" | "label"
 > & {
   hjelpetekst?: string;
   fraDatoLabel: string;
@@ -712,7 +712,7 @@ export interface SeksjonDefinisjonDto {
 
 export type SelectFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "label" | "pakrevd"
+  "pakrevd" | "label"
 > & {
   hjelpetekst?: string;
   alternativer: AlternativDefinisjonDto[];
@@ -726,14 +726,14 @@ export interface SkjemaDefinisjonDto {
 
 export type TextFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "label" | "pakrevd"
+  "pakrevd" | "label"
 > & {
   hjelpetekst?: string;
 };
 
 export type TextareaFeltDefinisjon = UtilRequiredKeys<
   FeltDefinisjonDto,
-  "label" | "pakrevd"
+  "pakrevd" | "label"
 > & {
   hjelpetekst?: string;
   /** @format int32 */

--- a/app/tests/e2e/fixtures/test-data.ts
+++ b/app/tests/e2e/fixtures/test-data.ts
@@ -52,6 +52,7 @@ export const testArbeidsgiverSkjema: UtsendtArbeidstakerSkjemaDto = {
     representasjonstype: Representasjonstype.ARBEIDSGIVER,
     juridiskEnhetOrgnr: "123456789",
     arbeidsgiverNavn: "Test Bedrift AS",
+    arbeidstakerNavn: "Test Bruker",
     skjemadel: Skjemadel.ARBEIDSGIVERS_DEL,
   } as ArbeidsgiverMetadata,
   data: {
@@ -72,6 +73,7 @@ export const testArbeidstakerSkjema: UtsendtArbeidstakerSkjemaDto = {
     representasjonstype: Representasjonstype.DEG_SELV,
     juridiskEnhetOrgnr: "123456789",
     arbeidsgiverNavn: "Test Bedrift AS",
+    arbeidstakerNavn: "Test Bruker",
     skjemadel: Skjemadel.ARBEIDSTAKERS_DEL,
   } as DegSelvMetadata,
   data: {

--- a/app/tests/e2e/fixtures/test-data.ts
+++ b/app/tests/e2e/fixtures/test-data.ts
@@ -284,6 +284,7 @@ export const testKombinertSkjema: UtsendtArbeidstakerSkjemaDto = {
     representasjonstype: Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT,
     juridiskEnhetOrgnr: "123456789",
     arbeidsgiverNavn: "Test Bedrift AS",
+    arbeidstakerNavn: "Test Bruker",
     skjemadel: Skjemadel.ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL,
     fullmektigFnr: "01019000083",
   } as ArbeidsgiverMedFullmaktMetadata,

--- a/app/tests/e2e/pages/skjema/innsendt-skjema.page.ts
+++ b/app/tests/e2e/pages/skjema/innsendt-skjema.page.ts
@@ -1,6 +1,7 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
 import { nb } from "~/i18n/nb";
+import type { UtsendtArbeidstakerSkjemaDto } from "~/types/melosysSkjemaTypes";
 
 const translations = nb.translation.innsendtSkjema;
 
@@ -63,5 +64,28 @@ export class InnsendtSkjemaPage {
 
   async assertReferanseIdVisible(referanseId: string) {
     await expect(this.page.getByText(referanseId)).toBeVisible();
+  }
+
+  async assertArbeidstakerOgArbeidsgiverInfo(
+    skjema: UtsendtArbeidstakerSkjemaDto,
+  ) {
+    await expect(
+      this.page.locator(`dt:has-text("${nb.translation.felles.navn}") + dd`),
+    ).toHaveText(skjema.metadata.arbeidstakerNavn);
+    await expect(
+      this.page.locator(
+        `dt:has-text("${nb.translation.oversiktFelles.arbeidstakerFnrLabel}") + dd`,
+      ),
+    ).toHaveText(skjema.fnr);
+    await expect(
+      this.page.locator(
+        `dt:has-text("${nb.translation.felles.virksomhetsnavn}") + dd`,
+      ),
+    ).toHaveText(skjema.metadata.arbeidsgiverNavn);
+    await expect(
+      this.page.locator(
+        `dt:has-text("${nb.translation.felles.organisasjonsnummer}") + dd`,
+      ),
+    ).toHaveText(skjema.orgnr);
   }
 }

--- a/app/tests/e2e/pages/skjema/innsendt-skjema.page.ts
+++ b/app/tests/e2e/pages/skjema/innsendt-skjema.page.ts
@@ -70,21 +70,21 @@ export class InnsendtSkjemaPage {
     skjema: UtsendtArbeidstakerSkjemaDto,
   ) {
     await expect(
-      this.page.locator(`dt:has-text("${nb.translation.felles.navn}") + dd`),
+      this.page.locator(`dt:text-is("${nb.translation.felles.navn}") + dd`),
     ).toHaveText(skjema.metadata.arbeidstakerNavn);
     await expect(
       this.page.locator(
-        `dt:has-text("${nb.translation.oversiktFelles.arbeidstakerFnrLabel}") + dd`,
+        `dt:text-is("${nb.translation.oversiktFelles.arbeidstakerFnrLabel}") + dd`,
       ),
     ).toHaveText(skjema.fnr);
     await expect(
       this.page.locator(
-        `dt:has-text("${nb.translation.felles.virksomhetsnavn}") + dd`,
+        `dt:text-is("${nb.translation.felles.virksomhetsnavn}") + dd`,
       ),
     ).toHaveText(skjema.metadata.arbeidsgiverNavn);
     await expect(
       this.page.locator(
-        `dt:has-text("${nb.translation.felles.organisasjonsnummer}") + dd`,
+        `dt:text-is("${nb.translation.felles.organisasjonsnummer}") + dd`,
       ),
     ).toHaveText(skjema.orgnr);
   }

--- a/app/tests/e2e/pages/skjema/oppsummering-steg.page.ts
+++ b/app/tests/e2e/pages/skjema/oppsummering-steg.page.ts
@@ -61,21 +61,21 @@ export class OppsummeringStegPage {
 
   async assertArbeidstakerOgArbeidsgiverInfo() {
     await expect(
-      this.page.locator(`dt:has-text("${nb.translation.felles.navn}") + dd`),
+      this.page.locator(`dt:text-is("${nb.translation.felles.navn}") + dd`),
     ).toHaveText(this.skjema.metadata.arbeidstakerNavn);
     await expect(
       this.page.locator(
-        `dt:has-text("${nb.translation.oversiktFelles.arbeidstakerFnrLabel}") + dd`,
+        `dt:text-is("${nb.translation.oversiktFelles.arbeidstakerFnrLabel}") + dd`,
       ),
     ).toHaveText(this.skjema.fnr);
     await expect(
       this.page.locator(
-        `dt:has-text("${nb.translation.felles.virksomhetsnavn}") + dd`,
+        `dt:text-is("${nb.translation.felles.virksomhetsnavn}") + dd`,
       ),
     ).toHaveText(this.skjema.metadata.arbeidsgiverNavn);
     await expect(
       this.page.locator(
-        `dt:has-text("${nb.translation.felles.organisasjonsnummer}") + dd`,
+        `dt:text-is("${nb.translation.felles.organisasjonsnummer}") + dd`,
       ),
     ).toHaveText(this.skjema.orgnr);
   }

--- a/app/tests/e2e/pages/skjema/oppsummering-steg.page.ts
+++ b/app/tests/e2e/pages/skjema/oppsummering-steg.page.ts
@@ -59,6 +59,27 @@ export class OppsummeringStegPage {
     await expect(this.heading).toBeVisible();
   }
 
+  async assertArbeidstakerOgArbeidsgiverInfo() {
+    await expect(
+      this.page.locator(`dt:has-text("${nb.translation.felles.navn}") + dd`),
+    ).toHaveText(this.skjema.metadata.arbeidstakerNavn);
+    await expect(
+      this.page.locator(
+        `dt:has-text("${nb.translation.oversiktFelles.arbeidstakerFnrLabel}") + dd`,
+      ),
+    ).toHaveText(this.skjema.fnr);
+    await expect(
+      this.page.locator(
+        `dt:has-text("${nb.translation.felles.virksomhetsnavn}") + dd`,
+      ),
+    ).toHaveText(this.skjema.metadata.arbeidsgiverNavn);
+    await expect(
+      this.page.locator(
+        `dt:has-text("${nb.translation.felles.organisasjonsnummer}") + dd`,
+      ),
+    ).toHaveText(this.skjema.orgnr);
+  }
+
   // --- Arbeidsgiver assertions ---
 
   async assertArbeidsgiverensVirksomhetINorgeData(

--- a/app/tests/e2e/specs/skjema/innsendt-skjema.spec.ts
+++ b/app/tests/e2e/specs/skjema/innsendt-skjema.spec.ts
@@ -38,6 +38,9 @@ test.describe("Innsendt skjema", () => {
     await innsendtPage.goto();
     await innsendtPage.assertIsVisible();
     await innsendtPage.assertReferanseIdVisible("REF-AT-001");
+    await innsendtPage.assertArbeidstakerOgArbeidsgiverInfo(
+      testArbeidstakerSkjema,
+    );
   });
 
   test("Viser innsendt — arbeidsgivers del", async ({ page }) => {
@@ -61,6 +64,9 @@ test.describe("Innsendt skjema", () => {
     await innsendtPage.goto();
     await innsendtPage.assertIsVisible();
     await innsendtPage.assertReferanseIdVisible("REF-AG-001");
+    await innsendtPage.assertArbeidstakerOgArbeidsgiverInfo(
+      testArbeidsgiverSkjema,
+    );
   });
 
   test("Viser innsendt — kombinert (arbeidsgiver og arbeidstakers del)", async ({
@@ -83,5 +89,8 @@ test.describe("Innsendt skjema", () => {
     await innsendtPage.goto();
     await innsendtPage.assertIsVisible();
     await innsendtPage.assertReferanseIdVisible("REF-KO-001");
+    await innsendtPage.assertArbeidstakerOgArbeidsgiverInfo(
+      testKombinertSkjema,
+    );
   });
 });

--- a/app/tests/e2e/specs/skjema/kvittering.spec.ts
+++ b/app/tests/e2e/specs/skjema/kvittering.spec.ts
@@ -23,6 +23,7 @@ test.describe("Kvittering", () => {
     representasjonstype: Representasjonstype.DEG_SELV,
     juridiskEnhetOrgnr: "123456789",
     arbeidsgiverNavn: "Test Bedrift AS",
+    arbeidstakerNavn: "Test Arbeidstaker",
     skjemadel: Skjemadel.ARBEIDSTAKERS_DEL,
     metadatatype: "DegSelvMetadata",
   };

--- a/app/tests/e2e/specs/skjema/oppsummering.spec.ts
+++ b/app/tests/e2e/specs/skjema/oppsummering.spec.ts
@@ -86,6 +86,7 @@ test.describe("Oppsummering", () => {
       await oppsummeringPage.goto();
       await oppsummeringPage.assertIsVisible();
 
+      await oppsummeringPage.assertArbeidstakerOgArbeidsgiverInfo();
       await oppsummeringPage.assertArbeidssituasjonData(arbeidssituasjonData);
       await oppsummeringPage.assertUtsendingsperiodeOgLandData(
         utsendingsperiodeOgLandData,


### PR DESCRIPTION
## Summary

- Ny komponent `ArbeidstakerOgArbeidsgiverOppsummering` viser arbeidstaker (navn + fnr) og arbeidsgiver (virksomhetsnavn + orgnr) øverst på `OppsummeringSteg` og `InnsendtSkjemaPage`
- Eksporterer `ARBEIDSGIVER_IKON`/`ARBEIDSTAKER_IKON` fra `stegRekkefølge.ts` så ikon + aria-label er enkeltkilde
- Regenererte TS-typer mot backend-PR navikt/melosys-skjema-api#265 — `arbeidstakerNavn` er non-nullable og optionale felter er ikke lenger `T | null`

## Bakgrunn

[MELOSYS-8055](https://jira.adeo.no/browse/MELOSYS-8055): Oppsummeringssiden manglet info om hvem søknaden gjaldt. Bilde i ticket viste at person og arbeidsgiver bør komme først i visningen.

> [!IMPORTANT]
> Avhenger av navikt/melosys-skjema-api#265 — typene må regenereres etter at backend er deployet til dev.


<img width="828" height="1088" alt="image" src="https://github.com/user-attachments/assets/6be87457-9f7c-45a1-99ce-96d352dfc0cb" />

