### PR TITLE
MELOSYS-8042 fiks trunkering av orgnr ved innliming med mellomrom

### DIFF
--- a/app/src/components/OrganisasjonSoker.tsx
+++ b/app/src/components/OrganisasjonSoker.tsx
@@ -86,7 +86,7 @@ export function OrganisasjonSoker({
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const digitsOnly = e.target.value.replaceAll(/\D/g, "");
+    const digitsOnly = e.target.value.replaceAll(/\D/g, "").slice(0, 9);
     setSearchValue(digitsOnly);
     if (valgtOrganisasjon) {
       setValue(formFieldName, null);
@@ -100,7 +100,6 @@ export function OrganisasjonSoker({
         error={getErrorMessage()}
         inputMode="numeric"
         label={label}
-        maxLength={9}
         onChange={handleChange}
         size="medium"
         value={searchValue}


### PR DESCRIPTION
`maxLength={9}` på orgnr-feltet kuttet inputen ved 9 *tegn* (inkl. mellomrom) før onChange fikk strippet mellomrommene. Innlimt "991 609 407" ble til "9916094".

Stripper nå ikke-sifre først, så trunkerer til 9 sifre i `handleChange`. Gjelder også rådgiverfirma og norske virksomheter, som bruker samme komponent.