### PR TITLE
8039 Tekstlige justeringer i søknaden

### DIFF
--- a/app/src/constants/skjemaDefinisjonA1.ts
+++ b/app/src/constants/skjemaDefinisjonA1.ts
@@ -363,7 +363,7 @@ const SKJEMA_DEFINISJON_A1_NB = {
         },
         vegadresse: {
           type: "TEXT",
-          label: "Vegadresse",
+          label: "Gate/vei",
           pakrevd: false,
         },
         nummer: {

--- a/app/src/i18n/nb.ts
+++ b/app/src/i18n/nb.ts
@@ -104,7 +104,7 @@ export const nb = {
     },
     soknadHeader: {
       soknadForUtsendtArbeidstakerInnenEuEosOgSveits:
-        "Søknad for utsendt arbeidstaker innen EU/EØS og sveits",
+        "Søknad for utsendt arbeidstaker innen EU/EØS og Sveits",
     },
     landVelgerFormPart: {
       velgLand: "Velg land",
@@ -176,7 +176,7 @@ export const nb = {
       tittel: "Arbeidssituasjon",
       fullmaktFraArbeidstakerTittel: "Du har fullmakt fra arbeidstaker",
       fullmaktFraArbeidstakerBeskrivelse:
-        "De neste spørsmålene svarer du på vegne av arbeidstaker.",
+        "De neste spørsmålene besvarer du på vegne av arbeidstaker.",
       duMaSvarePaOmDuHarVertEllerSkalVareILonnetArbeidINorgeForUtsending:
         "Du må svare på om du har vært eller skal være i lønnet arbeid i Norge før utsending",
       duMaBeskriveAktivitetenNarDuIkkeHarVertILonnetArbeid:
@@ -208,7 +208,7 @@ export const nb = {
         "Du må velge om arbeidstakeren har fast arbeidssted eller om det veksler ofte",
       duMaSvarePaOmDetErHjemmekontor:
         "Du må svare på om arbeidstakeren er utsendt for å jobbe på hjemmekontor",
-      vegadresseErPakrevd: "Vegadresse er påkrevd",
+      vegadresseErPakrevd: "Gate/vei er påkrevd",
       nummerErPakrevd: "Nummer er påkrevd",
       postkodeErPakrevd: "Postkode er påkrevd",
       byStedErPakrevd: "By/sted/region er påkrevd",


### PR DESCRIPTION
Tre tekstlige justeringer i søknadsdialogen for utsendt arbeidstaker.

Rettelser meldt inn fra fagpersonell — feil i stor/liten bokstav, ordvalg og feltlabel.
[MELOSYS-8039](https://jira.adeo.no/browse/MELOSYS-8039)

- "sveits" → "Sveits" i søknadstittel (stor bokstav)
- "svarer" → "besvarer" i infoboks under arbeidssituasjon-steget
- "Vegadresse" → "Gate/vei" i feltlabel og valideringsmelding (synkronisert fra backend)

## Testing
- [x] Enhetstester (vitest — 17/17)
- [x] E2E-tester (Playwright — 324/324)
- [x] Lint og typesjekk

