### PR TITLE
8060 7978: Endre tekst på spørsmål om land til generisk form

### DIFF
--- a/app/src/constants/skjemaDefinisjonA1.ts
+++ b/app/src/constants/skjemaDefinisjonA1.ts
@@ -247,7 +247,7 @@ const SKJEMA_DEFINISJON_A1_NB = {
         },
         tilleggsopplysningerTilSoknad: {
           type: "TEXTAREA",
-          label: "Beskriv de flere opplysningene du har til søknaden",
+          label: "Beskriv disse her",
           pakrevd: false,
           maxLength: 2000,
         },
@@ -652,7 +652,7 @@ const SKJEMA_DEFINISJON_A1_NB = {
         },
         tilleggsopplysningerTilSoknad: {
           type: "TEXTAREA",
-          label: "Beskriv de flere opplysningene du har til søknaden",
+          label: "Beskriv disse her",
           pakrevd: false,
           maxLength: 2000,
         },
@@ -903,8 +903,7 @@ const SKJEMA_DEFINISJON_A1_EN = {
         },
         tilleggsopplysningerTilSoknad: {
           type: "TEXTAREA",
-          label:
-            "Describe the additional information you have for the application",
+          label: "Describe them here",
           pakrevd: false,
           maxLength: 2000,
         },
@@ -1310,8 +1309,7 @@ const SKJEMA_DEFINISJON_A1_EN = {
         },
         tilleggsopplysningerTilSoknad: {
           type: "TEXTAREA",
-          label:
-            "Describe the additional information you have for the application",
+          label: "Describe them here",
           pakrevd: false,
           maxLength: 2000,
         },

--- a/app/src/constants/skjemaDefinisjonA1.ts
+++ b/app/src/constants/skjemaDefinisjonA1.ts
@@ -15,7 +15,7 @@ const SKJEMA_DEFINISJON_A1_NB = {
       felter: {
         utsendelseLand: {
           type: "COUNTRY_SELECT",
-          label: "I hvilket land skal du utføre arbeid?",
+          label: "I hvilket land skal arbeidet utføres?",
           pakrevd: true,
         },
         utsendelsePeriode: {
@@ -670,7 +670,7 @@ const SKJEMA_DEFINISJON_A1_EN = {
       felter: {
         utsendelseLand: {
           type: "COUNTRY_SELECT",
-          label: "In which country will you be working?",
+          label: "In which country will the work be performed?",
           pakrevd: true,
         },
         utsendelsePeriode: {

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -330,8 +330,8 @@ export const en = {
     },
     utsendingsperiodeOgLandSteg: {
       tittel: "Posting period and country",
-      duMaVelgeHvilketLandDuSkalUtforeArbeid:
-        "You must select which country you will perform work in",
+      duMaVelgeHvilketLandArbeidetSkalUtforesI:
+        "You must select which country the work will be performed in",
     },
     utenlandsoppdragetSteg: {
       tittel: "The Foreign Assignment",

--- a/app/src/i18n/nb.ts
+++ b/app/src/i18n/nb.ts
@@ -272,8 +272,8 @@ export const nb = {
     },
     utsendingsperiodeOgLandSteg: {
       tittel: "Utsendingsperiode og land",
-      duMaVelgeHvilketLandDuSkalUtforeArbeid:
-        "Du må velge hvilket land du skal utføre arbeid",
+      duMaVelgeHvilketLandArbeidetSkalUtforesI:
+        "Du må velge hvilket land arbeidet skal utføres i",
     },
     arbeidstakerenslonnSteg: {
       tittel: "Arbeidstakerens lønn",

--- a/app/src/pages/skjema/utsendingsperiode-og-land/utsendingsperiodeOgLandStegSchema.ts
+++ b/app/src/pages/skjema/utsendingsperiode-og-land/utsendingsperiodeOgLandStegSchema.ts
@@ -5,7 +5,7 @@ import { LandKode } from "~/types/melosysSkjemaTypes.ts";
 
 export const utsendingsperiodeOgLandSchema = z.object({
   utsendelseLand: z.enum(LandKode, {
-    error: "utsendingsperiodeOgLandSteg.duMaVelgeHvilketLandDuSkalUtforeArbeid",
+    error: "utsendingsperiodeOgLandSteg.duMaVelgeHvilketLandArbeidetSkalUtforesI",
   }),
 
   utsendelsePeriode: periodeSchema,

--- a/app/src/pages/skjema/utsendingsperiode-og-land/utsendingsperiodeOgLandStegSchema.ts
+++ b/app/src/pages/skjema/utsendingsperiode-og-land/utsendingsperiodeOgLandStegSchema.ts
@@ -5,7 +5,8 @@ import { LandKode } from "~/types/melosysSkjemaTypes.ts";
 
 export const utsendingsperiodeOgLandSchema = z.object({
   utsendelseLand: z.enum(LandKode, {
-    error: "utsendingsperiodeOgLandSteg.duMaVelgeHvilketLandArbeidetSkalUtforesI",
+    error:
+      "utsendingsperiodeOgLandSteg.duMaVelgeHvilketLandArbeidetSkalUtforesI",
   }),
 
   utsendelsePeriode: periodeSchema,

--- a/app/tests/e2e/pages/skjema/utsendingsperiode-og-land-steg.page.ts
+++ b/app/tests/e2e/pages/skjema/utsendingsperiode-og-land-steg.page.ts
@@ -20,7 +20,7 @@ const stegTittel = nb.translation.utsendingsperiodeOgLandSteg.tittel;
 // Feilmeldinger
 const feilmeldinger = {
   land: nb.translation.utsendingsperiodeOgLandSteg
-    .duMaVelgeHvilketLandDuSkalUtforeArbeid,
+    .duMaVelgeHvilketLandArbeidetSkalUtforesI,
   datoErPakrevd: nb.translation.periode.datoErPakrevd,
   tilDatoForFraDato: nb.translation.periode.tilDatoMaVareEtterFraDato,
 };


### PR DESCRIPTION
Synker skjemadefinisjonen fra backend ([melosys-skjema-api#278](https://github.com/navikt/melosys-skjema-api/pull/278)) og endrer tilhørende valideringsmelding til samme generiske formulering («arbeidet skal utføres»).

Slår ut i skjema, oppsummering og tidligere innsendte søknader.