### PR TITLE
7987 Sett riktig språkkode på html-elementet

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="no">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -28,6 +28,9 @@ const getDecoratorLangFromCookie = () => {
   );
 };
 
+const i18nLangToHtmlLang = (lng: string): string =>
+  lng === "en" ? "en" : "no";
+
 i18n.use(initReactI18next).init({
   lng: getDecoratorLangFromCookie(),
   fallbackLng: "nb",
@@ -35,6 +38,12 @@ i18n.use(initReactI18next).init({
   interpolation: {
     escapeValue: false,
   },
+});
+
+// Sett riktig lang-attributt på <html> ved oppstart og ved språkbytte
+document.documentElement.lang = i18nLangToHtmlLang(i18n.language);
+i18n.on("languageChanged", (lng) => {
+  document.documentElement.lang = i18nLangToHtmlLang(lng);
 });
 
 export const queryClient = new QueryClient();


### PR DESCRIPTION
Setter riktig `lang`-attributt på `<html>`-elementet i henhold til WCAG 3.1.1.

UU-gjennomgang avdekket at `<html lang="en">` var hardkodet i index.html,
selv om applikasjonen primært er norsk. Språkkoden skal reflektere
faktisk innholdsspråk, og oppdateres dynamisk ved språkbytte.
[MELOSYS-7987](https://jira.adeo.no/browse/MELOSYS-7987)

- Endret default `lang` fra `"en"` til `"no"` i `index.html`
- Dynamisk oppdatering av `document.documentElement.lang` ved oppstart og ved i18n-språkbytte
- Mapping: `nb` → `"no"`, `en` → `"en"`

## Testing
- [x] Typesjekk (`pnpm check-types`)
- [x] Enhetstester (`pnpm test` — 26/26 grønne)
- [x] Manuell testing: verifiser at `<html lang>` oppdateres ved språkbytte i dekoratøren
