### PR TITLE
Sett BASE_PATH ved byggetid og legg path på alle ingresser

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -49,6 +49,8 @@ jobs:
       - name: Build app
         run: pnpm build
         working-directory: app
+        env:
+          BASE_PATH: /medlemskap-lovvalg/soknad/
 
       - name: Install server dependencies
         run: pnpm install --frozen-lockfile

--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   port: 8080
   ingresses:
-    - https://melosys-skjema-web.intern.dev.nav.no
+    - https://melosys-skjema-web.intern.dev.nav.no/medlemskap-lovvalg/soknad
   replicas:
     min: 1
     max: 2

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   port: 8080
   ingresses:
-    - https://melosys-skjema-web.intern.nav.no
+    - https://melosys-skjema-web.intern.nav.no/medlemskap-lovvalg/soknad
     - https://www.nav.no/medlemskap-lovvalg/soknad
   replicas:
     min: 2
@@ -61,8 +61,6 @@ spec:
         - id: loki
         - id: elastic
   env:
-    - name: BASE_PATH
-      value: /medlemskap-lovvalg/soknad/
     - name: API_URL
       value: http://melosys-skjema-api/api
     - name: API_SCOPE


### PR DESCRIPTION
PR #452 satte `BASE_PATH` som runtime-env i NAIS, men Vite sin `base`-option er en byggetidsting — asset-stiene bakes inn i HTML-en og bundlen når Vite bygger. Resultatet ble at appen fortsatt prøvde å laste assets fra `nav.no/assets/...` istedenfor `nav.no/medlemskap-lovvalg/soknad/assets/...`.

Ved å bruke samme path-prefiks på alle ingresser slipper vi å bygge separate images per miljø. Q1/Q2 (når de innføres) bør følge samme konvensjon.

Verifisert at `BASE_PATH` kun leses av `app/vite.config.ts`, ikke av serveren.
