### PR TITLE
Mont Express-routene under BASE_PATH

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -58,6 +58,8 @@ spec:
         - id: loki
         - id: elastic
   env:
+    - name: BASE_PATH
+      value: /medlemskap-lovvalg/soknad/
     - name: API_URL
       value: http://melosys-skjema-api/api
     - name: API_SCOPE

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -61,6 +61,8 @@ spec:
         - id: loki
         - id: elastic
   env:
+    - name: BASE_PATH
+      value: /medlemskap-lovvalg/soknad/
     - name: API_URL
       value: http://melosys-skjema-api/api
     - name: API_SCOPE

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -53,6 +53,9 @@ export interface RouterContext {
 }
 
 const router = createRouter({
+  // Basepath må matche Vite sin `base` slik at client-side routing
+  // jobber relativt til /medlemskap-lovvalg/soknad/ i prod og "/" lokalt
+  basepath: import.meta.env.BASE_URL,
   scrollRestoration: true,
   routeTree,
   context: {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,10 +1,16 @@
 const clusterName = process.env.NAIS_CLUSTER_NAME ?? "";
 const env = clusterName.startsWith("prod") ? "prod" : "dev";
 
+// NAIS-ingressen stripper ikke path-prefiksen, så Express må selv montere
+// app-routene under BASE_PATH. Trailing slash fjernes så mount-pathen blir
+// "/foo" (Express-konvensjon), ikke "/foo/".
+const basePath = (process.env.BASE_PATH ?? "").replace(/\/+$/, "");
+
 const app = {
   env: env as "dev" | "prod",
   host: process.env.EXPRESS_HOST ?? "::",
   port: Number(process.env.EXPRESS_PORT ?? "8080"),
+  basePath,
 };
 
 export default {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2,6 +2,7 @@ import express from "express";
 
 import { setupActuators } from "./actuators.js";
 import { setupApiProxy, setupDekoratorenApiProxy } from "./apiProxy.js";
+import config from "./config.js";
 import { errorHandling } from "./errorHandler.js";
 import { setupStaticRoutes } from "./frontendRoute.js";
 import logger from "./logger.js";
@@ -23,7 +24,7 @@ setupDekoratorenApiProxy(protectedRouter);
 // Catch all route, må være sist
 setupStaticRoutes(protectedRouter);
 
-app.use(protectedRouter);
+app.use(config.app.basePath, protectedRouter);
 
 app.use(errorHandling);
 


### PR DESCRIPTION
Etter at appen ble lagt på subpathen `/medlemskap-lovvalg/soknad/` (PR #453) returnerte Express index.html med MIME `text/html` for alle asset-requests:

``` 
Refused to apply style from '.../assets/index-CL8XB73j.css' because its MIME type ('text/html')
Failed to load module script: ... server responded with a MIME type of "text/html"
``` 

NAIS-ingressen stripper ikke path-prefiksen, så Express får request på `/medlemskap-lovvalg/soknad/assets/...` mens filene fysisk ligger på `./public/assets/...`. `express.static` finner ikke fila, og `*splat`-catchallen returnerer index.html med HTTP 200 — derav 200-statusen Isa observerte i Network-fanen.

Løsningen er å montere alle app-routene under `BASE_PATH` så Express stripper prefiksen før mount-relativ resolving. Actuators (`/internal/health/*`) er fortsatt på root så NAIS-probes fungerer uendret.