### PR TITLE
Prefiks fetch-URL-er med BASE_URL i httpClients

### DIFF
--- a/app/src/httpClients/dekoratorenClient.ts
+++ b/app/src/httpClients/dekoratorenClient.ts
@@ -19,7 +19,9 @@ export function getUserInfo() {
 }
 
 async function fetchUserInfo(): Promise<UserInfo> {
-  const response = await fetch("/nav-dekoratoren-api/auth");
+  const response = await fetch(
+    `${import.meta.env.BASE_URL}nav-dekoratoren-api/auth`,
+  );
 
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);

--- a/app/src/httpClients/melsosysSkjemaApiClient.ts
+++ b/app/src/httpClients/melsosysSkjemaApiClient.ts
@@ -35,7 +35,7 @@ import {
   ValideringError,
 } from "~/utils/valideringUtils.ts";
 
-const API_PROXY_URL = "/api";
+const API_PROXY_URL = `${import.meta.env.BASE_URL}api`;
 
 type StegData =
   | ArbeidsgiverensVirksomhetINorgeDto

--- a/app/src/utils/validateSkjemaDefinisjon.ts
+++ b/app/src/utils/validateSkjemaDefinisjon.ts
@@ -12,7 +12,7 @@ import {
   type SupportedLanguage,
 } from "~/constants/skjemaDefinisjonA1";
 
-const API_PROXY_URL = "/api";
+const API_PROXY_URL = `${import.meta.env.BASE_URL}api`;
 
 interface ValidationResult {
   isValid: boolean;


### PR DESCRIPTION
Prefikser alle frontend fetch-URL-er med `import.meta.env.BASE_URL`. Når appen kjører på `/medlemskap-lovvalg/soknad/` traff absolutte paths som `/api/...` og `/nav-dekoratoren-api/auth` aldri Express-proxyen — de gikk til `www.nav.no/api/...` utenfor vår ingress.

Verifisert at det ikke er flere absolutte paths igjen (fetch, window.location, new URL, form action, JSX href/src). Tanstack Router har allerede basepath fra forrige PR.