### PR TITLE
Legg til nynorsk (nn) og forbetre engelske (en) oversettingar

### DIFF
--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -12,7 +12,7 @@ export const en = {
       lagre: "Save",
       lagreOgFortsett: "Save and continue",
       sendSoknad: "Submit application",
-      skjemaSendtInn: "Application submitted",
+      skjemaSendtInn: "Form submitted",
       avbryt: "Cancel",
       ja: "Yes",
       nei: "No",
@@ -50,7 +50,7 @@ export const en = {
     skjemaVeiledning: {
       hei: "Hello",
       guidePanelTekst1:
-        "The GuidePanel section is used for brief, high-level guidance to the applicant. The section retrieves the applicant's name and provides a condensed explanation of the financial support, measure, or aid. This text is taken from the introduction to the product page on nav.no.",
+        "The GuidePanel section is used for brief, high-level guidance to the applicant. The section retrieves the applicant's name and provides a condensed explanation of the cash benefits, measure, or aid. This text is taken from the introduction to the product page on nav.no.",
       guidePanelTekst2:
         "End the text in the section with a link to the product page on nav.no that opens in a new tab.",
       forDuSoker: "Before you apply",
@@ -128,13 +128,13 @@ export const en = {
       regionValgfritt: "Region (optional)",
       land: "Country",
       tilhorerVirksomhetenSammeKonsernSomDenNorskeArbeidsgiveren:
-        "Does the company belong to the same consortium as the Norwegian employer?",
+        "Does the company belong to the same group as the Norwegian employer?",
       leggTilUtenlandskVirksomhet: "Add foreign company",
       endreUtenlandskVirksomhet: "Edit foreign company",
       ansettelsesform: "What do you work as in this company?",
       arbeidstakerEllerFrilanser: "Employee or freelancer",
       selvstendigNaeringsdrivende: "Self-employed",
-      statsansatt: "Government employee",
+      statsansatt: "Civil servant",
     },
     arbeidssituasjonSteg: {
       tittel: "Work situation",
@@ -142,18 +142,6 @@ export const en = {
         "You have power of attorney from the employee",
       fullmaktFraArbeidstakerBeskrivelse:
         "The following questions are answered on behalf of the employee.",
-      harDuVaertEllerSkalVaereILonnetArbeidINorgeIMinst1ManedRettForUtsendingen:
-        "Have you been or will you be in paid employment in Norway for at least one month right before the posting?",
-      beskriveAktivitetFoerUtsending:
-        "Describe your activity in the month before the posting",
-      beskriveAktivitetFoerUtsendingBeskrivelse:
-        "For example studies, vacation or self-employment",
-      skalDuOgsaDriveSelvstendigVirksomhetEllerJobbeForEnAnnenArbeidsgiver:
-        "Will you also work for another employer or run a self-employed business during the posting period?",
-      leggTilVirksomheterDuSkalJobbeForBeskrivelse:
-        "Add Norwegian and/or foreign companies you will work for during the posting period.",
-      hvemSkalDuJobbeForIUtsendelsesPerioden:
-        "Who will you work for during the posting period?",
       duMaSvarePaOmDuHarVertEllerSkalVareILonnetArbeidINorgeForUtsending:
         "You must answer whether you have been or will be in paid employment in Norway before posting",
       duMaBeskriveAktivitetenNarDuIkkeHarVertILonnetArbeid:
@@ -164,26 +152,22 @@ export const en = {
         "You must add at least one company when you will work for multiple companies",
     },
     familiemedlemmerSteg: {
-      tittel: "Family Members",
+      tittel: "Family members",
       duMaSvarePaOmDuHarFamiliemedlemmerSomSkalVaereMed:
         "You must answer whether you have a spouse, partner, cohabitant or children who will accompany you",
       informasjonOmEgenSoknad:
         "If family members need clarification of their social security affiliation, they must submit their own application. Accompanying family members can apply using the form:",
       soknadsskjemaLenke: "https://www.nav.no/fyllut/nav020807?lang=en",
       soknadsskjemaNavn:
-        "application for determination of applicable social security legislation during a stay in the EEA or Switzerland",
+        "application for determination of social security affiliation during a stay in the EEA or Switzerland",
       somLiggerPaNavNo: " available at nav.no.",
       sendeSoknadForBarn:
-        "You can submit an application for children under 18 using this form.",
+        "You can submit an application for children under 18 using the aforementioned form.",
     },
     tilleggsopplysningerSteg: {
-      tittel: "Additional Information",
-      harDuNoenFlereOpplysningerTilSoknaden:
-        "Do you have any additional information for the application?",
+      tittel: "Additional information",
       duMaSvarePaOmDuHarFlereOpplysningerTilSoknaden:
         "You must answer whether you have additional information for the application",
-      beskriveFlereOpplysningerTilSoknaden:
-        "Describe the additional information you have for the application",
       tilleggsopplysningerErPakrevdNarDuHarFlereOpplysninger:
         "Additional information is required when you have additional information",
     },
@@ -206,27 +190,14 @@ export const en = {
     skatteforholdOgInntektSteg: {
       tittel: "Tax conditions and income",
       inntektHeading: "Income",
-      erDuSkattepliktigTilNorgeIHeleUtsendingsperioden:
-        "Are you liable to pay tax to Norway for the entire posting period?",
-      mottarDuPengestotteFraEtAnnetEosLandEllerSveits:
-        "Do you receive financial support from another EEA country or Switzerland?",
-      mottarDuPengestotteBeskrivelse:
-        "By «financial support» we mean money you receive as compensation for lost income from work. Sickness benefits, parental benefits, unemployment benefits and work assessment allowance are examples of such financial support in Norway.",
-      fraHvilketLandMottarDuPengestotte:
-        "From which country do you receive financial support?",
-      hvorMyePengerMottarDuBruttoPerManed:
-        "How much money do you receive gross per month",
-      oppgiBelopetINorskeKroner: "Enter the amount in Norwegian kroner",
-      hvaSlagsPengestotteMottarDu:
-        "What kind of financial support do you receive",
       duMaSvarePaOmDuErSkattepliktigTilNorgeIHeleUtsendingsperioden:
         "You must answer whether you are liable to pay tax to Norway for the entire posting period",
       duMaSvarePaOmDuMottarPengestotteFraEtAnnetEosLandEllerSveits:
-        "You must answer whether you receive financial support from another EEA country or Switzerland",
+        "You must answer whether you receive cash benefits from another EEA country or Switzerland",
       duMaBeskriveHvaSlagsPengestotteDuMottar:
-        "You must describe what kind of financial support you receive",
+        "You must describe what type of cash benefits you receive",
       duMaVelgeHvilketLandSomUtbetalerPengestotten:
-        "You must select which country pays the financial support",
+        "You must select which country pays the cash benefits",
       duMaOppgiEtGyldigBelopSomErStorreEnn0:
         "You must enter a valid amount greater than 0",
       duMaVelgeMinstEnInntektKilde:
@@ -238,46 +209,7 @@ export const en = {
     },
     arbeidsstedIUtlandetSteg: {
       tittel: "Place of work abroad",
-      hvorSkalArbeidetUtfores: "Where will the work be performed?",
       velgArbeidssted: "Select workplace",
-      paLand: "On land",
-      offshore: "Offshore",
-      paSkip: "On ship",
-      omBordPaFly: "On board an aircraft",
-      harFastArbeidsstedEllerVeksler:
-        "Does the employee have a fixed place of work in this country or does it vary frequently?",
-      fastArbeidssted: "Fixed place of work",
-      vekslerOfte: "Varies frequently",
-      vegadresse: "Street address",
-      nummer: "Number",
-      postkode: "Postal code",
-      bySted: "City/place/region",
-      erHjemmekontor: "Is the employee posted to work from home office?",
-      navnPaInnretning: "Name of installation",
-      hvilkenTypeInnretning: "What type of installation is this?",
-      plattformEllerFast: "Platform or other fixed installation",
-      boreskipEllerFlyttbar: "Drilling ship or other mobile installation",
-      hvilketLandsSokkel: "Which country's continental shelf is this?",
-      navnPaSkip: "What is the name of the ship the employee will work on?",
-      yrketTilArbeidstaker: "What is the employee's occupation?",
-      yrketTilArbeidstakerBeskrivelse:
-        "We need information about what kind of work the employee performs on board the ship",
-      hvorSkalSkipetSeile: "Where will the ship sail?",
-      internasjonaltFarvann: "International waters",
-      territorialfarvann: "Within territorial waters",
-      flaggland: "What is the flag country of the ship?",
-      hvilketLandsTerritorialfarvann: "Which country's territorial waters?",
-      hjemmebaseLand:
-        "In which country does the employee have their home base during the application period?",
-      hjemmebaseLandBeskrivelse:
-        "By home base we mean the airport where the employee starts and ends their flights",
-      hjemmebaseNavn: "What is the name of the home base?",
-      erVanligHjemmebase:
-        "Is this the home base the employee usually works from?",
-      vanligHjemmebaseLand:
-        "In which country is the home base the employee usually works from located?",
-      vanligHjemmebaseNavn:
-        "What is the name of the home base the employee usually works from?",
       // Error messages
       duMaVelgeArbeidsstedType:
         "You must select where the work will be performed",
@@ -297,7 +229,7 @@ export const en = {
       navnPaSkipErPakrevd: "Name of the ship is required",
       yrketTilArbeidstakerErPakrevd: "Employee's occupation is required",
       duMaVelgeHvorSkipetSeiler: "You must select where the ship will sail",
-      flagglandErPakrevd: "Flag country is required",
+      flagglandErPakrevd: "Flag state is required",
       territorialfarvannLandErPakrevd:
         "You must select which country's territorial waters the ship sails in",
       hjemmebaseLandErPakrevd:
@@ -309,21 +241,10 @@ export const en = {
         "You must select which country the usual home base is located in",
       vanligHjemmebaseNavnErPakrevd:
         "The name of the usual home base is required",
-      navnPaVirksomhet: "Name of the business",
       navnPaVirksomhetErPakrevd: "Name of the business is required",
     },
     arbeidsgiverensVirksomhetINorgeSteg: {
       tittel: "Employer's business in Norway",
-      erArbeidsgiverenEnOffentligVirksomhet:
-        "Is the employer a public enterprise?",
-      offentligeVirksomheterErStatsorganerOgUnderliggendeVirksomheter:
-        "Public enterprises are state bodies and subordinate enterprises, for example ministries and universities.",
-      erArbeidsgiverenEtBemanningsEllerVikarbyra:
-        "Is the employer a staffing or temporary work agency?",
-      opprettholderArbeidsgiverenVanligDriftINorge:
-        "Does the employer maintain normal operations in Norway?",
-      medDetteMenerViAtArbeidsgivereFortsattHarAktivitetOgAnsatteSomJobberINorgeIPerioden:
-        "By this we mean that the employer still has activity and employees working in Norway during the period.",
       duMaSvarePaOmArbeidsgiverenErEnOffentligVirksomhet:
         "You must answer whether the employer is a public enterprise",
       duMaSvarePaOmArbeidsgiverenErEtBemanningsEllerVikarbyra:
@@ -337,24 +258,7 @@ export const en = {
         "You must select which country the work will be performed in",
     },
     utenlandsoppdragetSteg: {
-      tittel: "The Foreign Assignment",
-      hvilketLandSendesArbeidstakerenTil:
-        "To which country is the employee being sent?",
-      utsendingsperiode: "Assignment period",
-      harDuSomArbeidsgiverOppdragILandetArbeidstakerSkalSendesUtTil:
-        "Do you as an employer have assignments in the country where the employee will be sent?",
-      hvorforSkalArbeidstakerenArbeideIUtlandet:
-        "Why should the employee work abroad?",
-      bleArbeidstakerAnsattPaGrunnAvDetteUtenlandsoppdraget:
-        "Was the employee hired because of this foreign assignment?",
-      vilArbeidstakerenArbeideForVirksomhetenINorgeEtterUtenlandsoppdraget:
-        "Will the employee work for the company in Norway after the foreign assignment?",
-      vilArbeidstakerFortsattVareAnsattHostDereIHeleUtsendingsperioden:
-        "Will the employee still be employed by you during the entire assignment period?",
-      beskrivArbeidstakerensAnsettelsesforholdIUtsendingsperioden:
-        "Describe the employee's employment relationship during the assignment period",
-      erstatterArbeidstakerEnAnnenPersonSomVarSendtUtForAGjoreDetSammeArbeidet:
-        "Is the employee replacing another person who was sent out to do the same work?",
+      tittel: "Foreign assignment",
       duMaVelgeHvilketLandArbeidstakerenSendesTil:
         "You must select which country the employee is being sent to",
       duMaSvarePaOmDereHarOppdragILandet:
@@ -362,27 +266,23 @@ export const en = {
       duMaSvarePaOmArbeidstakerBleAnsattPaGrunnAvDetteUtenlandsoppdraget:
         "You must answer whether the employee was hired because of this foreign assignment",
       duMaSvarePaOmArbeidstakerVilFortsattVareAnsattIHeleUtsendingsperioden:
-        "You must answer whether the employee will still be employed during the entire assignment period",
+        "You must answer whether the employee will still be employed during the entire posting period",
       duMaSvarePaOmArbeidstakerErstatterEnAnnenPerson:
         "You must answer whether the employee is replacing another person",
+      tilDatoKanIkkeVareForFraDato: "To date cannot be before from date",
       begrunnelseErPakrevdNarArbeidsgiverIkkeHarOppdragILandet:
-        "Justification is required when employer does not have assignments in the country",
+        "Justification is required when the employer does not have assignments in the country",
       beskrivelseAvAnsettelsesforholdErPakrevd:
         "Description of employment relationship is required",
       duMaSvarePaOmArbeidstakerenVilArbeideForVirksomhetenINorgeEtterOppdraget:
         "You must answer whether the employee will work for the company in Norway after the assignment",
-      oppgiOmtrentligDatoHvisDuIkkeVetNoyaktigDato:
-        "Enter approximate date if you don't know the exact date.",
-      forrigeArbeidstakersUtsendelse: "Previous employee's assignment",
+      fraDatoForForrigeArbeidstakerErPakrevd:
+        "From date for previous employee is required",
+      tilDatoForForrigeArbeidstakerErPakrevd:
+        "To date for previous employee is required",
     },
     arbeidstakerenslonnSteg: {
       tittel: "Employee's salary",
-      utbetalerDuSomArbeidsgiverAllLonnOgEventuelleNaturalyttelserIUtsendingsperioden:
-        "Do you as an employer pay all salary and any benefits in kind during the posting period?",
-      hvemUtbetalerLonnenOgEventuelleNaturalytelser:
-        "Who pays the salary and any benefits in kind?",
-      leggTilNorskeOgEllerUtenlandskeVirksomheterSomUtbetalerLonnenOgEventuelleNaturalytelser:
-        "Add Norwegian and/or foreign companies that pay the salary and any benefits in kind",
       duMaSvarePaOmDuBetalerAllLonnOgEventuelleNaturalyttelserIUtsendingsperioden:
         "You must answer whether you pay all salary and any benefits in kind during the posting period",
       duMaLeggeTilMinstEnVirksomhetNarDuIkkeBetalerAllLonnSelv:
@@ -501,6 +401,8 @@ export const en = {
         "Select the employee you want to fill out an application for",
       arbeidstakerMedFullmaktBeskrivelse:
         "The list contains all employees who have granted you a mandate",
+      arbeidstakerIngenFullmakter:
+        "You have not been granted a mandate from any employees. The employee can grant you a mandate on",
       arbeidstakerSelvUtfyllingCheckbox:
         "The employee will fill out their part of the application themselves",
       arbeidstakerMedFullmaktPlaceholder: "Birth/d-number or name",
@@ -509,11 +411,11 @@ export const en = {
       arbeidstakerUtenFullmaktBeskrivelse:
         "The employee must complete their part of the application themselves.",
       arbeidstakerFnrLabel: "Birth/d-number",
-      arbeidstakerFulltNavnLabel: "Full name",
+      arbeidstakerFulltNavnLabel: "Last name",
       arbeidstakerSokKnapp: "Search",
       arbeidstakerFnrTom: "Enter birth number",
       arbeidstakerFnrUgyldig: "Invalid birth number",
-      arbeidstakerFulltNavnTom: "Enter full name",
+      arbeidstakerFulltNavnTom: "Enter last name",
       arbeidstakerVerifiseringFeilet:
         "Person not found with the specified birth number and last name",
       arbeidstakerVerifisertLabel: "Person verified",
@@ -533,7 +435,7 @@ export const en = {
       historikkKolonneRefnr: "Ref.no.",
       historikkKolonneFodselsdato: "Date of birth",
       historikkKolonneArbeidsgiver: "Employer",
-      historikkSeSkjema: "View application",
+      historikkSeSkjema: "View form",
       historikkKolonneStatus: "Status",
       historikkAntallTreff: "{{antall}} results",
       historikkFeilmelding:
@@ -542,6 +444,8 @@ export const en = {
       historikkStatusSendt: "Submitted",
       historikkStatusMottatt: "Received",
       orgnrLabel: "Org. no:",
+      feilVedOpprettelse:
+        "An error occurred while creating the application. Please try again later.",
       paginationForrige: "Previous",
       paginationNeste: "Next",
     },
@@ -552,23 +456,8 @@ export const en = {
       sokPaVirksomhet: "Search for company (org.no.)",
       duMaSokeForstFeil:
         "You must search for and select an advisory firm before you can continue",
-      valgtFirma: "Selected advisory firm",
+      valgtFirma: "Selected organization",
       ok: "Ok",
-    },
-    startSoknad: {
-      tittel: "Start application",
-      beskrivelse:
-        "Check that the information below is correct before starting the application.",
-      organisasjonsnavn: "Organization name",
-      organisasjonsnummer: "Organization number",
-      radgiverfirmaTittel: "Advisory firm",
-      navn: "Name",
-      fodselsnummer: "Birth number / D-number",
-      duHarFullmakt:
-        "You have mandate to complete the application on behalf of the employee",
-      startSoknadKnapp: "Start application",
-      feilVedOpprettelse:
-        "An error occurred while creating the application. Please try again later.",
     },
     periode: {
       fraDato: "From date",
@@ -584,10 +473,10 @@ export const en = {
       organisasjonsnummerMaVare9Siffer: "Organization number must be 9 digits",
       navnPaVirksomhetErPakrevd: "Company name is required",
       vegnavnOgHusnummerErPakrevd:
-        "Street address and house number is required",
+        "Street address and house number are required",
       landErPakrevd: "Country is required",
       duMaSvarePaOmVirksomhetenTilhorerSammeKonsern:
-        "You must answer whether the company belongs to the same consortium",
+        "You must answer whether the company belongs to the same group",
       ansettelsesformErPakrevd: "You must select an employment form",
       organisasjonIkkeFunnet: "No organization found with this number",
       feilVedSok: "Something went wrong with the search. Try again later.",

--- a/app/src/i18n/i18n.ts
+++ b/app/src/i18n/i18n.ts
@@ -1,7 +1,9 @@
 import { en } from "./en.ts";
 import { nb } from "./nb.ts";
+import { nn } from "./nn.ts";
 
 export const resources = {
   nb,
+  nn,
   en,
 };

--- a/app/src/i18n/nn.ts
+++ b/app/src/i18n/nn.ts
@@ -5,7 +5,8 @@ export const nn = {
       feil: "Det oppstod ein feil",
       feilVedLastingAvSkjema: "Feil ved lasting av skjema",
       fantIkkeSkjema: "Fann ikkje skjema",
-      stegIkkeTilgjengelig: "Steget er ikkje tilgjengeleg for denne skjemadelen",
+      stegIkkeTilgjengelig:
+        "Steget er ikkje tilgjengeleg for denne skjemadelen",
       brukerinfoMangler: "Brukarinfo manglar",
       kunneIkkeOppretteSkjema: "Kunne ikkje opprette skjema. Prøv igjen.",
       manglerOrganisasjonsnummer: "Manglar organisasjonsnummer",
@@ -167,7 +168,8 @@ export const nn = {
       lastOppVedleggBeskrivelse:
         "Du kan laste opp PDF eller bilete (JPG, PNG). Maks filstorleik 10 MB per fil.",
       feilForStor: "Fila er for stor. Maks filstorleik er 10 MB.",
-      feilUgyldigFormat: "Ugyldig filformat. Berre PDF, JPG og PNG er tillatne.",
+      feilUgyldigFormat:
+        "Ugyldig filformat. Berre PDF, JPG og PNG er tillatne.",
       feilVirusFunnet:
         "Fila vart avvist fordi ho kan innehalde skadeleg innhald.",
       feilUkjent: "Kunne ikkje laste opp fila. Prøv igjen seinare.",
@@ -202,7 +204,8 @@ export const nn = {
         "Du må velje kva land som utbetaler pengestøtta",
       duMaOppgiEtGyldigBelopSomErStorreEnn0:
         "Du må oppgi eit gyldig beløp som er større enn 0",
-      duMaVelgeMinstEnInntektKilde: "Du må velje minst éi arbeidsinntektskjelde",
+      duMaVelgeMinstEnInntektKilde:
+        "Du må velje minst éi arbeidsinntektskjelde",
       duMaVelgeMinstEnInntektType: "Du må velje minst éin inntektstype",
       duMaOppgiLonnsinntekt: "Du må oppgi lønsinntekt",
       duMaOppgiInntektFraEgenVirksomhet:

--- a/app/src/i18n/nn.ts
+++ b/app/src/i18n/nn.ts
@@ -1,0 +1,528 @@
+export const nn = {
+  translation: {
+    felles: {
+      laster: "Lastar...",
+      feil: "Det oppstod ein feil",
+      feilVedLastingAvSkjema: "Feil ved lasting av skjema",
+      fantIkkeSkjema: "Fann ikkje skjema",
+      stegIkkeTilgjengelig: "Steget er ikkje tilgjengeleg for denne skjemadelen",
+      brukerinfoMangler: "Brukarinfo manglar",
+      kunneIkkeOppretteSkjema: "Kunne ikkje opprette skjema. Prøv igjen.",
+      manglerOrganisasjonsnummer: "Manglar organisasjonsnummer",
+      lagre: "Lagre",
+      lagreOgFortsett: "Lagre og hald fram",
+      sendSoknad: "Send søknad",
+      skjemaSendtInn: "Skjema sendt inn",
+      avbryt: "Avbryt",
+      ja: "Ja",
+      nei: "Nei",
+      tilbake: "Tilbake",
+      neste: "Neste",
+      fjern: "Fjern",
+      endre: "Endre",
+      leggTil: "Legg til",
+      endreSvar: "Endre svar",
+      pakrevd: "påkravd",
+      forrigeSteg: "Førre steg",
+      nesteSteg: "Neste steg",
+      sistOppdatert: "Sist oppdatert: {{tidspunkt}}",
+      lagreUtkastOgFortsettSenere: "Lagre utkast og hald fram seinare",
+      avbrytOgSlett: "Avbryt og slett",
+      avbrytOgSlettUtkast: "Avbryt og slett utkast?",
+      alleOpplysningerVilBliSlettet:
+        "Alle opplysningane du har fylt ut vil bli sletta",
+      neiFortsettUtfylling: "Nei, hald fram med utfyllinga",
+      jaAvbrytOgSlettUtkast: "Ja, avbryt og slett utkast",
+      lagreUtkastBeskrivelse:
+        "Skjemaet blir lagra som eit utkast på Mi side slik at du kan fullføre seinare.",
+      jaLagreOgFortsettSenere: "Ja, lagre og hald fram seinare",
+      startSoknad: "Start søknad",
+      valgtVirksomhet: "Vald verksemd",
+      valgtOrganisasjon: "Vald organisasjon",
+      navn: "Namn",
+      ugyldigFodselsnummerEllerDnummer: "Ugyldig fødselsnummer eller D-nummer",
+      stegGjelderArbeidsgiver: "Dette steget gjeld arbeidsgivar",
+      stegGjelderArbeidstaker: "Dette steget gjeld arbeidstakar",
+      virksomhetsnavn: "Verksemdsnamn",
+      organisasjonsnummer: "Organisasjonsnummer",
+    },
+    periode: {
+      fraDato: "Frå dato",
+      tilDato: "Til dato",
+      datoErPakrevd: "Du må fylle inn ein gyldig dato",
+      tilDatoMaVareEtterFraDato: "Til-dato kan ikkje vere før frå-dato",
+    },
+    skjemaVeiledning: {
+      hei: "Hei",
+      guidePanelTekst1:
+        "Seksjonen GuidePanel blir brukt til ei kort, overordna rettleiing til søkaren. Seksjonen hentar inn søkarens namn, og gjev ei komprimert forklaring av pengestøtta, tiltaket eller hjelpemiddelet. Denne teksten blir henta frå ingressen til produktsida på nav.no.",
+      guidePanelTekst2:
+        "Avslutt teksten i seksjonen med ei lenkje til produktsida på nav.no som blir opna i ny fane.",
+      forDuSoker: "Før du søker",
+      denneSeksjonenBrukesTil:
+        "Denne seksjonen blir brukt til å gi søkarane informasjon dei vil ha stor nytte av før dei går i gang med søknaden. Eksempel på nyttig informasjon:",
+      oppgaverBrukerenMaHaGjort: "Oppgåver brukaren må ha gjort før dei søker.",
+      duMaHaMeldtDegSomArbeidssøker:
+        "Du må ha meldt deg som arbeidssøkar før du kan søke om dagpengar.",
+      dokumentasjonBrukerenKanBliBedtOm:
+        "Dokumentasjon brukaren kan bli beden om.",
+      noenAvOpplysningeneViBeOmDokumentation:
+        "Nokre av opplysningane du gjev undervegs vil du bli beden om å dokumentere. Du vil trenge xx og xx for å fullføre denne søknaden.",
+      automatiskLagring: "Automatisk lagring.",
+      viLagrerSvarene:
+        "Vi lagrar svara dine (xx timar) medan du fyller ut, slik at du kan ta pausar undervegs.",
+      antallStegOgEstimertTidsbruk: "Tal på steg og estimert tidsbruk.",
+      detErXXStegISoknaden:
+        "Det er XX steg i søknaden, og du kan rekne med å bruke ca. XX minutt.",
+      soknadsfrist: "Søknadsfristar.",
+      huskAtDuMaSokeOmXX: "Hugs at du må søke om xx innan xx dagar.",
+      saksbehandlingstiderOgInfo:
+        "Saksbehandlingstider og info om gyldigheit, krav osv.",
+      viBrukerCaXXUker:
+        "Vi brukar ca. xx veker på å behandle søknaden din. Hugs at du må sende meldekort xx ofte sjølv om du ikkje har fått svar på søknaden din om dagpengar endå.",
+      forAnnenUtfyllendeInformasjon:
+        "For anna, utfyllande informasjon om søknaden bør du lenkje direkte til søknadskapittelet i produktsida, som",
+      detteEksempeletForDagpenger: "dette eksempelet for dagpengar",
+      informasjonViHenterOmDeg: "Informasjon vi hentar om deg",
+      herSkalDetStaInformasjonOmHvorVi:
+        "Her skal det stå informasjon om kor vi vil hente opplysningar om søkaren og kva slags opplysningar vi hentar.",
+      hvordanViBehandlerPersonopplysninger:
+        "Korleis vi behandlar personopplysningar",
+      herSkalDetStaInformasjonOmHvordanVi:
+        "Her skal det stå informasjon om korleis vi behandlar personopplysningane til søkaren.",
+      automatiskSaksbehandling: "Automatisk saksbehandling",
+      herSkalDetStaInformasjonOmHvaAutomatisk:
+        "Her skal det stå informasjon om kva automatisk behandling er, kva det betyr for søkaren og informasjon om søkarens rettar ved automatisk avslag.",
+      viLagrerSvarUnderveis: "Vi lagrar svar undervegs",
+      herSkalDetStaInformasjonOmHvordanDenne:
+        "Her skal det stå informasjon om korleis denne søknaden mellomlagrar informasjonen til søkaren og kor lenge informasjonen blir lagra. Vi skal informere om mellomlagring ved både automatisk lagring og ved samtykke til lagring med lagreknappen.",
+      detErViktigAtDuGirOss:
+        "Det er viktig at du gjev oss riktige opplysningar slik at vi kan behandle saka di.",
+      lesMerOmViktigheten:
+        "Les meir om kor viktig det er å gje riktige opplysningar.",
+      jegBekrefter: "Eg stadfestar at eg vil svare så riktig som eg kan.",
+    },
+    soknadHeader: {
+      soknadForUtsendtArbeidstakerInnenEuEosOgSveits:
+        "Søknad for utsendt arbeidstakar innanfor EU/EØS og Sveits",
+    },
+    landVelgerFormPart: {
+      velgLand: "Vel land",
+    },
+    norskeVirksomheterFormPart: {
+      norskVirksomhet: "Norsk verksemd",
+      norskeVirksomheter: "Norske verksemder",
+      organisasjonsnummer: "Organisasjonsnummer",
+      leggTilNorskVirksomhet: "Legg til norsk verksemd",
+      endreNorskVirksomhet: "Endre norsk verksemd",
+      kunneIkkeFInneOrganisasjon:
+        "Kunne ikkje finne organisasjon med organisasjonsnummer",
+    },
+    utenlandskeVirksomheterFormPart: {
+      utenlandskVirksomhet: "Utanlandsk verksemd",
+      utenlandskeVirksomheter: "Utanlandske verksemder",
+      navnPaVirksomhet: "Namn på verksemd",
+      organisasjonsnummerEllerRegistreringsnummerValgfritt:
+        "Organisasjonsnummer eller registreringsnummer (valfritt)",
+      vegnavnOgHusnummerEvtPostboks:
+        "Vegnamn og husnummer, eventuelt postboksadresse",
+      bygningValgfritt: "Bygning (valfritt)",
+      postkodeValgfritt: "Postkode (valfritt)",
+      byStednavnValgfritt: "By/stadnamn (valfritt)",
+      regionValgfritt: "Region (valfritt)",
+      land: "Land",
+      tilhorerVirksomhetenSammeKonsernSomDenNorskeArbeidsgiveren:
+        "Tilhøyrer verksemda same konsern som den norske arbeidsgivaren?",
+      leggTilUtenlandskVirksomhet: "Legg til utanlandsk verksemd",
+      endreUtenlandskVirksomhet: "Endre utanlandsk verksemd",
+      ansettelsesform: "Kva jobbar du som i denne verksemda?",
+      arbeidstakerEllerFrilanser: "Arbeidstakar eller frilansar",
+      selvstendigNaeringsdrivende: "Sjølvstendig næringsdrivande",
+      statsansatt: "Statstilsett",
+    },
+    familiemedlemmerSteg: {
+      tittel: "Familiemedlemmar",
+      duMaSvarePaOmDuHarFamiliemedlemmerSomSkalVaereMed:
+        "Du må svare på om du har ektefelle, partnar, sambuar eller barn som skal vere med deg",
+      informasjonOmEgenSoknad:
+        "Dersom familiemedlemmar treng avklaring av trygdetilhøyrsle, må dei sende inn eigen søknad. Medfølgande familiemedlemmar kan søke i skjemaet:",
+      soknadsskjemaLenke: "https://www.nav.no/fyllut/nav020807?lang=nn-NO",
+      soknadsskjemaNavn:
+        "søknad om avklaring av trygdetilhøyrsle under opphald i EØS eller Sveits",
+      somLiggerPaNavNo: " som ligg på nav.no.",
+      sendeSoknadForBarn:
+        "Du kan sende søknad for barn under 18 år på det nemnde skjemaet.",
+    },
+    tilleggsopplysningerSteg: {
+      tittel: "Tilleggsopplysningar",
+      duMaSvarePaOmDuHarFlereOpplysningerTilSoknaden:
+        "Du må svare på om du har fleire opplysningar til søknaden",
+      tilleggsopplysningerErPakrevdNarDuHarFlereOpplysninger:
+        "Tilleggsopplysningar er påkravd når du har fleire opplysningar",
+    },
+    vedleggSteg: {
+      tittel: "Vedlegg",
+      ingenVedleggLastetOpp: "Ingen vedlegg lasta opp",
+      lastOppVedlegg: "Last opp vedlegg",
+      lastOppVedleggBeskrivelse:
+        "Du kan laste opp PDF eller bilete (JPG, PNG). Maks filstorleik 10 MB per fil.",
+      feilForStor: "Fila er for stor. Maks filstorleik er 10 MB.",
+      feilUgyldigFormat: "Ugyldig filformat. Berre PDF, JPG og PNG er tillatne.",
+      feilVirusFunnet:
+        "Fila vart avvist fordi ho kan innehalde skadeleg innhald.",
+      feilUkjent: "Kunne ikkje laste opp fila. Prøv igjen seinare.",
+      duMaSvarePaOmDuHarAnnenDokumentasjon:
+        "Du må svare på om du har anna dokumentasjon du ønskjer å leggje ved",
+      duMaLasteOppMinstEttVedlegg: "Du må laste opp minst eitt vedlegg",
+    },
+    arbeidssituasjonSteg: {
+      tittel: "Arbeidssituasjon",
+      fullmaktFraArbeidstakerTittel: "Du har fullmakt frå arbeidstakar",
+      fullmaktFraArbeidstakerBeskrivelse:
+        "Dei neste spørsmåla svarer du på vegner av arbeidstakar.",
+      duMaSvarePaOmDuHarVertEllerSkalVareILonnetArbeidINorgeForUtsending:
+        "Du må svare på om du har vore eller skal vere i løna arbeid i Noreg før utsending",
+      duMaBeskriveAktivitetenNarDuIkkeHarVertILonnetArbeid:
+        "Du må skildre aktiviteten din når du ikkje har vore i løna arbeid",
+      duMaSvarePaOmDuSkalJobbeForFlereVirksomheterIPerioden:
+        "Du må svare på om du skal jobbe for fleire verksemder i perioden",
+      duMaLeggeTilMinstEnVirksomhetNarDuSkalJobbeForFlereVirksomheter:
+        "Du må leggje til minst éi verksemd når du skal jobbe for fleire verksemder",
+    },
+    skatteforholdOgInntektSteg: {
+      tittel: "Skatteforhold og inntekt",
+      inntektHeading: "Inntekt",
+      duMaSvarePaOmDuErSkattepliktigTilNorgeIHeleUtsendingsperioden:
+        "Du må svare på om du er skattepliktig til Noreg i heile utsendingsperioden",
+      duMaSvarePaOmDuMottarPengestotteFraEtAnnetEosLandEllerSveits:
+        "Du må svare på om du tek imot pengestøtte frå eit anna EØS-land eller Sveits",
+      duMaBeskriveHvaSlagsPengestotteDuMottar:
+        "Du må skildre kva slags pengestøtte du tek imot",
+      duMaVelgeHvilketLandSomUtbetalerPengestotten:
+        "Du må velje kva land som utbetaler pengestøtta",
+      duMaOppgiEtGyldigBelopSomErStorreEnn0:
+        "Du må oppgi eit gyldig beløp som er større enn 0",
+      duMaVelgeMinstEnInntektKilde: "Du må velje minst éi arbeidsinntektskjelde",
+      duMaVelgeMinstEnInntektType: "Du må velje minst éin inntektstype",
+      duMaOppgiLonnsinntekt: "Du må oppgi lønsinntekt",
+      duMaOppgiInntektFraEgenVirksomhet:
+        "Du må oppgi inntekt frå eiga verksemd",
+    },
+    arbeidsstedIUtlandetSteg: {
+      tittel: "Arbeidsstad i utlandet",
+      velgArbeidssted: "Vel arbeidsstad",
+      // Feilmeldingar
+      duMaVelgeArbeidsstedType: "Du må velje kor arbeidet skal utførast",
+      duMaVelgeFastEllerVekslende:
+        "Du må velje om arbeidstakaren har fast arbeidsstad eller om det vekslar ofte",
+      duMaSvarePaOmDetErHjemmekontor:
+        "Du må svare på om arbeidstakaren er utsendt for å jobbe på heimekontor",
+      vegadresseErPakrevd: "Gate/veg er påkravd",
+      nummerErPakrevd: "Nummer er påkravd",
+      postkodeErPakrevd: "Postkode er påkravd",
+      byStedErPakrevd: "By/stad/region er påkravd",
+      navnPaInnretningErPakrevd: "Namn på innretning er påkravd",
+      duMaVelgeTypeInnretning: "Du må velje kva type innretning dette er",
+      sokkelLandErPakrevd: "Du må velje kva lands sokkel dette er",
+      navnPaSkipErPakrevd: "Namn på skipet er påkravd",
+      yrketTilArbeidstakerErPakrevd: "Yrket til arbeidstakaren er påkravd",
+      duMaVelgeHvorSkipetSeiler: "Du må velje kor skipet skal segle",
+      flagglandErPakrevd: "Flaggland er påkravd",
+      territorialfarvannLandErPakrevd:
+        "Du må velje kva lands territorialfarvatn skipet seglar i",
+      hjemmebaseLandErPakrevd:
+        "Du må velje kva land arbeidstakaren har heimebase i",
+      hjemmebaseNavnErPakrevd: "Namnet på heimebasen er påkravd",
+      duMaSvarePaOmDetErVanligHjemmebase:
+        "Du må svare på om dette er heimebasen arbeidstakaren jobbar frå til vanleg",
+      vanligHjemmebaseLandErPakrevd:
+        "Du må velje kva land den vanlege heimebasen ligg i",
+      vanligHjemmebaseNavnErPakrevd:
+        "Namnet på den vanlege heimebasen er påkravd",
+      navnPaVirksomhetErPakrevd: "Namn på verksemda er påkravd",
+    },
+    arbeidsgiverensVirksomhetINorgeSteg: {
+      tittel: "Verksemda til arbeidsgivaren i Noreg",
+      duMaSvarePaOmArbeidsgiverenErEnOffentligVirksomhet:
+        "Du må svare på om arbeidsgivaren er ei offentleg verksemd",
+      duMaSvarePaOmArbeidsgiverenErEtBemanningsEllerVikarbyra:
+        "Du må svare på om arbeidsgivaren er eit bemannings- eller vikarbyrå",
+      duMaSvarePaOmArbeidsgiverenOpprettholderVanligDriftINorge:
+        "Du må svare på om arbeidsgivaren held oppe vanleg drift i Noreg",
+    },
+    utenlandsoppdragetSteg: {
+      tittel: "Utanlandsoppdraget",
+      duMaVelgeHvilketLandArbeidstakerenSendesTil:
+        "Du må velje kva land arbeidstakaren blir sendt til",
+      duMaSvarePaOmDereHarOppdragILandet:
+        "Du må svare på om de har oppdrag i landet",
+      duMaSvarePaOmArbeidstakerBleAnsattPaGrunnAvDetteUtenlandsoppdraget:
+        "Du må svare på om arbeidstakar vart tilsett på grunn av dette utanlandsoppdraget",
+      duMaSvarePaOmArbeidstakerVilFortsattVareAnsattIHeleUtsendingsperioden:
+        "Du må svare på om arbeidstakar framleis vil vere tilsett i heile utsendingsperioden",
+      duMaSvarePaOmArbeidstakerErstatterEnAnnenPerson:
+        "Du må svare på om arbeidstakar erstattar ein annan person",
+      tilDatoKanIkkeVareForFraDato: "Til dato kan ikkje vere før frå dato",
+      begrunnelseErPakrevdNarArbeidsgiverIkkeHarOppdragILandet:
+        "Grunngiving er påkravd når arbeidsgivar ikkje har oppdrag i landet",
+      beskrivelseAvAnsettelsesforholdErPakrevd:
+        "Skildring av tilsetjingsforhold er påkravd",
+      duMaSvarePaOmArbeidstakerenVilArbeideForVirksomhetenINorgeEtterOppdraget:
+        "Du må svare på om arbeidstakaren vil arbeide for verksemda i Noreg etter oppdraget",
+      fraDatoForForrigeArbeidstakerErPakrevd:
+        "Frå-dato for førre arbeidstakar er påkravd",
+      tilDatoForForrigeArbeidstakerErPakrevd:
+        "Til-dato for førre arbeidstakar er påkravd",
+    },
+    utsendingsperiodeOgLandSteg: {
+      tittel: "Utsendingsperiode og land",
+      duMaVelgeHvilketLandArbeidetSkalUtforesI:
+        "Du må velje kva land arbeidet skal utførast i",
+    },
+    arbeidstakerenslonnSteg: {
+      tittel: "Løna til arbeidstakaren",
+      duMaSvarePaOmDuBetalerAllLonnOgEventuelleNaturalyttelserIUtsendingsperioden:
+        "Du må svare på om du betaler all løn og eventuelle naturalytingar i utsendingsperioden",
+      duMaLeggeTilMinstEnVirksomhetNarDuIkkeBetalerAllLonnSelv:
+        "Du må leggje til minst éi verksemd når du ikkje betaler all løn sjølv",
+    },
+    landingsside: {
+      hei: "Hei",
+      hvemVilDuBrukeNavPaVegneAv: "Kven skal du opptre som?",
+      degSelv: "DEG SJØLV",
+      dinArbeidsgiver: "ARBEIDSGIVAR",
+      dinArbeidsgiverBeskrivelse:
+        "som fyller ut søknad for arbeidsgivar/arbeidstakar",
+      enArbeidsgiverSomRadgiver: "RÅDGIVAR",
+      enArbeidsgiverSomRadgiverBeskrivelse:
+        "som fyller ut søknad for arbeidsgivar/arbeidstakar",
+      annenPerson: "PRIVATPERSON",
+      annenPersonBeskrivelse: "som fyller ut søknad for ein annan person",
+      avbryt: "Avbryt",
+    },
+    appHeader: {
+      tittel: "Medlemskap og lovval",
+    },
+    kontekstVelger: {
+      arbeidsgiver: "Arbeidsgivar",
+      radgiver: "Rådgivar",
+      annenPerson: "Annan person",
+      byttKontekstAriaLabel: "Opne meny for å byte representasjon eller språk",
+    },
+    oversiktDegSelv: {
+      tittel: "Oversiktsside for søknader",
+      herKanDu: "Her kan du:",
+      infoBullet1: "fylle ut søknad.",
+      infoBullet2: "sjå påbyrja og tidlegare innsendte søknader.",
+    },
+    oversiktArbeidsgiver: {
+      tittel: "Oversiktsside for søknader",
+      herKanDu: "Her kan du:",
+      infoBullet1:
+        "fylle ut søknad for arbeidsgivaren din og deira arbeidstakarar.",
+      infoBullet2: "sjå tilgangar og fullmakter som du har fått.",
+      infoBullet3: "sjå påbyrja og tidlegare innsendte søknader.",
+    },
+    oversiktRadgiver: {
+      tittel: "Oversiktsside for søknader",
+      herKanDu: "Her kan du:",
+      infoBullet1:
+        "fylle ut søknad for ein arbeidsgivar og deira arbeidstakarar.",
+      infoBullet2: "sjå tilgangar og fullmakter som du har fått.",
+      infoBullet3: "sjå påbyrja og tidlegare innsendte søknader.",
+    },
+    oversiktAnnenPerson: {
+      tittel: "Oversiktsside for søknader",
+      herKanDu: "Her kan du:",
+      infoBullet1: "fylle ut søknad for personar som har gjeve deg fullmakt.",
+      infoBullet2: "sjå påbyrja og tidlegare innsendte søknader.",
+      personVelgerLabel: "Vel person du skal fylle ut søknad for",
+      personVelgerBeskrivelse:
+        "Lista inneheld alle personar du har fått fullmakt frå på nav.no.",
+    },
+    oversiktBekreftelse: {
+      intro:
+        "Det er viktig at du gjev oss riktige opplysningar slik at vi kan behandle saka.",
+      linkText: "Les meir om kor viktig det er å gje riktige opplysningar.",
+      linkUrl: "https://www.nav.no/endringer",
+      bekreftAtVilSvareRiktig:
+        "Eg stadfestar at eg vil svare så riktig som eg kan",
+      arbeidsgiverInfo:
+        "Du som arbeidsgivar vil ta imot alle brev om saksbehandlinga i Altinn.",
+      radgiverInfo:
+        "Verksemda du jobbar for vil ta imot alle brev om saksbehandlinga i Altinn så lenge tilgangen og fullmakta gjeld.",
+      annenPersonInfo:
+        "Du som fullmektig vil ta imot brev om saksbehandlinga så lenge fullmakta gjeld.",
+    },
+    oversiktFelles: {
+      utkastTittel: "UTKAST",
+      utkastBeskrivelse: "Påbyrja søknader du ikkje har sendt inn endå",
+      utkastFeilmelding:
+        "Kunne ikkje hente påbyrja søknader. Prøv å laste sida på nytt.",
+      utkastArbeidsgiver: "Arbeidsgivar",
+      utkastArbeidstaker: "Arbeidstakar",
+      utkastOpprettet: "Oppretta",
+      utkastSistEndret: "Sist endra",
+      soknadStarterTittel: "Kven skal du fylle ut søknaden på vegner av?",
+      soknadStarterTittelDegSelv: "Oppgi arbeidsgivar som sender deg ut",
+      soknadStarterTittelAnnenPerson:
+        "Kven skal du fylle ut søknaden på vegner av?",
+      soknadStarterInfoAnnenPerson:
+        "Vi treng informasjon om både personen du søker på vegner av og deira arbeidsgivar.",
+      soknadStarterInfo:
+        "Vi treng informasjon om både arbeidsgivar og arbeidstakar. Dersom du har fullmakt frå arbeidstakaren, skal du fylle ut for begge samtidig. Viss ikkje, hukar du av for at arbeidstakaren skal fylle ut sin del sjølv. Du må då oppgi namn og fødsels-/d-nummer før du startar søknaden.",
+      arbeidsgiverTittel: "Arbeidsgivar",
+      arbeidsgiverOrgnrLabel: "Organisasjonsnummer til arbeidsgivar",
+      arbeidsgiverVelgerLabel:
+        "Vel arbeidsgivar (organisasjonsnummer eller -namn)",
+      arbeidsgiverVelgerPlaceholder: "Organisasjonsnummer eller -namn",
+      arbeidsgiverVelgerInfo:
+        "Lista inneheld alle arbeidsgivarar du har fått tilgang til i Altinn.",
+      ingenArbeidsgivereTittel: "Du har ingen arbeidsgivarar tilgjengelege",
+      ingenArbeidsgivereInfo:
+        "For å kunne fylle ut søknad på vegner av ein arbeidsgivar, må du ha fått delegert tilgang til verksemda i Altinn.",
+      ingenArbeidsgivereLenke: "Les meir om korleis du får tilgang i Altinn",
+      feilVedHentingAvArbeidsgivere:
+        "Det oppstod ein feil ved henting av arbeidsgivarar frå Altinn. Prøv igjen seinare.",
+      arbeidstakerTittel: "Arbeidstakar",
+      skalFylleUtForArbeidstakerLabel:
+        "Skal du fylle ut søknaden for arbeidstakar?",
+      arbeidstakerMedFullmaktLabel:
+        "Vel arbeidstakar du skal fylle ut søknad for",
+      arbeidstakerMedFullmaktBeskrivelse:
+        "Lista inneheld alle arbeidstakarar du har fått fullmakt frå",
+      arbeidstakerIngenFullmakter:
+        "Du har ikkje fått fullmakt frå nokon arbeidstakarar. Arbeidstakar kan gje deg fullmakt på",
+      arbeidstakerSelvUtfyllingCheckbox:
+        "Arbeidstakaren skal sjølv fylle ut sin del av søknaden",
+      arbeidstakerMedFullmaktPlaceholder: "Fødsels-/d-nummer eller namn",
+      arbeidstakerMedFullmaktListePlaceholder: "+ Vel...",
+      arbeidstakerUtenFullmaktTittel: "Arbeidstakar utan fullmakt",
+      arbeidstakerUtenFullmaktBeskrivelse:
+        "Arbeidstakaren må sjølv fylle ut sin del av søknaden.",
+      arbeidstakerFnrLabel: "Fødsels-/d-nummer",
+      arbeidstakerFulltNavnLabel: "Etternamn",
+      arbeidstakerSokKnapp: "Søk",
+      arbeidstakerFnrTom: "Skriv fødselsnummer",
+      arbeidstakerFnrUgyldig: "Ugyldig fødselsnummer",
+      arbeidstakerFulltNavnTom: "Skriv etternamn",
+      arbeidstakerVerifiseringFeilet:
+        "Finn ikkje person med oppgitt fødselsnummer og etternamn",
+      arbeidstakerVerifisertLabel: "Person verifisert",
+      arbeidstakerFjernKnapp: "Fjern",
+      gaTilSkjemaKnapp: "Start søknad",
+      valideringFeilTittel: "Du må fylle ut desse felta:",
+      valideringManglerArbeidsgiver: "Arbeidsgivar må veljast",
+      valideringManglerArbeidstaker: "Arbeidstakar må veljast",
+      valideringManglerBekreftelseAtVilSvareRiktig:
+        "Du må stadfeste at du vil svare så riktig som du kan",
+      historikkTittel: "Tidlegare innsendte søknader",
+      historikkSokPlaceholder: "Søk...",
+      historikkKolonneVirksomhet: "Verksemd",
+      historikkKolonneArbeidstaker: "Arbeidstakar",
+      historikkKolonneFnr: "F.nr/D-nr",
+      historikkKolonneInnsendt: "Innsendt",
+      historikkKolonneRefnr: "Refnr.",
+      historikkKolonneFodselsdato: "Fødselsdato",
+      historikkKolonneArbeidsgiver: "Arbeidsgivar",
+      historikkSeSkjema: "Sjå skjema",
+      historikkKolonneStatus: "Status",
+      historikkAntallTreff: "{{antall}} treff",
+      historikkFeilmelding:
+        "Kunne ikkje hente innsendte søknader. Prøv igjen seinare.",
+      historikkIngenResultater: "Ingen søknader funne",
+      historikkStatusSendt: "Sendt",
+      historikkStatusMottatt: "Motteke",
+      paginationForrige: "Førre",
+      paginationNeste: "Neste",
+      orgnrLabel: "Org.nr:",
+      feilVedOpprettelse:
+        "Det oppstod ein feil ved oppretting av søknad. Prøv igjen seinare.",
+    },
+    velgRadgiverfirma: {
+      tittel: "Kva rådgjevingsfirma jobbar du hos?",
+      informasjon:
+        "Vi treng denne informasjonen for å sende brev til rett mottakar i Altinn.",
+      sokPaVirksomhet: "Søk på verksemd (org.nr.)",
+      duMaSokeForstFeil:
+        "Du må søke etter og velje eit rådgjevarfirma før du kan halde fram",
+      valgtFirma: "Vald organisasjon",
+      ok: "Ok",
+    },
+    oppsummeringSteg: {
+      tittel: "Oppsummering",
+      svarPaVegneAvArbeidstaker:
+        "Dei neste svara er på vegner av arbeidstakar.",
+    },
+    generellValidering: {
+      erPakrevd: "er påkravd",
+      organisasjonsnummerErPakrevd: "Organisasjonsnummer er påkravd",
+      organisasjonsnummerHarUgyldigFormat:
+        "Organisasjonsnummeret har ugyldig format",
+      organisasjonsnummerMaVare9Siffer: "Organisasjonsnummer må vere 9 siffer",
+      navnPaVirksomhetErPakrevd: "Namn på verksemd er påkravd",
+      vegnavnOgHusnummerErPakrevd: "Vegnamn og husnummer er påkravd",
+      landErPakrevd: "Land er påkravd",
+      duMaSvarePaOmVirksomhetenTilhorerSammeKonsern:
+        "Du må svare på om verksemda tilhøyrer same konsern",
+      ansettelsesformErPakrevd: "Du må velje ei tilsetjingsform",
+      organisasjonIkkeFunnet: "Fann ingen organisasjon med dette nummeret",
+      feilVedSok: "Noko gjekk gale ved søk. Prøv igjen seinare.",
+      ugyldigOrganisasjonsnummer: "Organisasjonsnummeret er ugyldig",
+      rateLimitOverskredet:
+        "Du har søkt for mange gonger. Vent eit minutt før du prøver igjen.",
+    },
+    innsendtSkjema: {
+      tittel: "Innsendt søknad",
+      arbeidstakersDel: "Arbeidstakaren sin del",
+      arbeidsgiverDel: "Arbeidsgivaren sin del",
+      tilbakeTilOversikt: "Tilbake til oversikt",
+      feilVedLasting: "Kunne ikkje hente innsendt søknad. Prøv igjen seinare.",
+    },
+    kvittering: {
+      tittel: "Takk!",
+      melding: "Vi har motteke søknaden din med referanse",
+      infoOversikt:
+        "Du kan sjå søknaden under «Tidlegare innsendte søknader» på oversiktssida for søknader.",
+      tilOversikt: "Gå til oversiktsside for søknader",
+    },
+    land: {
+      AT: "Austerrike",
+      AX: "Åland",
+      BE: "Belgia",
+      BG: "Bulgaria",
+      CH: "Sveits",
+      CY: "Kypros",
+      CZ: "Tsjekkia",
+      DE: "Tyskland",
+      DK: "Danmark",
+      EE: "Estland",
+      ES: "Spania",
+      FI: "Finland",
+      FO: "Færøyane",
+      FR: "Frankrike",
+      GB: "Storbritannia",
+      GL: "Grønland",
+      GR: "Hellas",
+      HR: "Kroatia",
+      HU: "Ungarn",
+      IE: "Irland",
+      IS: "Island",
+      IT: "Italia",
+      LI: "Liechtenstein",
+      LT: "Litauen",
+      LU: "Luxembourg",
+      LV: "Latvia",
+      MT: "Malta",
+      NL: "Nederland",
+      NO: "Noreg",
+      PL: "Polen",
+      PT: "Portugal",
+      RO: "Romania",
+      SE: "Sverige",
+      SI: "Slovenia",
+      SJ: "Svalbard og Jan Mayen",
+      SK: "Slovakia",
+    },
+  },
+};


### PR DESCRIPTION
## Endringar

### Ny fil
- `app/src/i18n/nn.ts` — fullstendige nynorske oversettingar

### Endra filer
- `app/src/i18n/en.ts` — forbetra engelske oversettingar
- `app/src/i18n/i18n.ts` — registrert nn som støtta språk

### Detaljar

**Nynorsk (nn.ts):**
- Alle nøklar frå nb.ts er omsette til nynorsk
- Kvalitetssikra gjennom fleire review-rundar

**Engelsk (en.ts):**
- Terminologi: «cash benefits», «civil servant», «group», «flag state»
- Fjerna overflødige nøklar som ikkje finst i nb.ts
- Lagt til 5 manglande nøklar frå nb.ts
- Fiksa grammatikk, konsistens i titlar (sentence case), og semantisk presisjon

**Bokmål (nb.ts):**
- Ikkje endra