### PR TITLE
8081 Legg til beskrivende feilmelding ved innsending

### DIFF
--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -46,6 +46,10 @@ export const en = {
       stegGjelderArbeidstaker: "This step applies to the employee",
       virksomhetsnavn: "Company name",
       organisasjonsnummer: "Organization number",
+      stegManglerUtfylling:
+        "You must complete the following steps before submitting the application",
+      feilVedInnsending:
+        "An error occurred while submitting the application. Please try again later.",
     },
     skjemaVeiledning: {
       hei: "Hello",

--- a/app/src/i18n/nb.ts
+++ b/app/src/i18n/nb.ts
@@ -45,6 +45,10 @@ export const nb = {
       stegGjelderArbeidstaker: "Dette steget gjelder arbeidstaker",
       virksomhetsnavn: "Virksomhetsnavn",
       organisasjonsnummer: "Organisasjonsnummer",
+      stegManglerUtfylling:
+        "Du må fylle ut følgende steg før du kan sende inn søknaden",
+      feilVedInnsending:
+        "Det oppstod en feil ved innsending av søknaden. Prøv igjen på et senere tidspunkt.",
     },
     periode: {
       fraDato: "Fra dato",

--- a/app/src/pages/skjema/components/SendInnSkjemaKnapp.tsx
+++ b/app/src/pages/skjema/components/SendInnSkjemaKnapp.tsx
@@ -2,7 +2,6 @@ import { PaperplaneIcon } from "@navikt/aksel-icons";
 import { Button } from "@navikt/ds-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -13,9 +12,15 @@ import {
 
 interface SendInnSkjemaKnappProps {
   skjemaId: string;
+  onBeforeSubmit: () => boolean;
+  onSubmitError: () => void;
 }
 
-export function SendInnSkjemaKnapp({ skjemaId }: SendInnSkjemaKnappProps) {
+export function SendInnSkjemaKnapp({
+  skjemaId,
+  onBeforeSubmit,
+  onSubmitError,
+}: SendInnSkjemaKnappProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -47,11 +52,15 @@ export function SendInnSkjemaKnapp({ skjemaId }: SendInnSkjemaKnappProps) {
       });
     },
     onError: () => {
-      toast.error(t("felles.feil"));
+      onSubmitError();
     },
   });
 
   const handleClick = () => {
+    if (!onBeforeSubmit()) {
+      return;
+    }
+
     sendInnSkjemaMutation.mutate();
   };
 

--- a/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
+++ b/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
@@ -50,7 +50,7 @@ function OppsummeringStegContent({
 
   useEffect(() => {
     if (harFeil) {
-      errorRef.current?.scrollIntoView({ behavior: "smooth" });
+      errorRef.current?.scrollIntoView({ behavior: "auto" });
       errorRef.current?.focus();
     }
   }, [harFeil]);

--- a/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
+++ b/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
@@ -78,21 +78,6 @@ function OppsummeringStegContent({
         />
       }
     >
-      {harFeil && (
-        <div ref={errorRef} className="mt-4" tabIndex={-1}>
-          {valideringsfeil.length > 0 ? (
-            <ErrorSummary heading={t("felles.stegManglerUtfylling")}>
-              {valideringsfeil.map((steg) => (
-                <ErrorSummary.Item key={steg.href} href={steg.href}>
-                  {t(steg.title)}
-                </ErrorSummary.Item>
-              ))}
-            </ErrorSummary>
-          ) : (
-            <Alert variant="error">{t("felles.feilVedInnsending")}</Alert>
-          )}
-        </div>
-      )}
       <ArbeidstakerOgArbeidsgiverOppsummering skjema={skjema} />
       {seksjoner.map(({ seksjonNavn, seksjon, data, stegKey }) => {
         const steg = stegRekkefolge.find((s) => s.key === stegKey);
@@ -122,6 +107,21 @@ function OppsummeringStegContent({
         harAnnenDokumentasjon={skjema.data.vedlegg?.harAnnenDokumentasjon}
         skjemaId={skjema.id}
       />
+      {harFeil && (
+        <div ref={errorRef} className="mt-4" tabIndex={-1}>
+          {valideringsfeil.length > 0 ? (
+            <ErrorSummary heading={t("felles.stegManglerUtfylling")}>
+              {valideringsfeil.map((steg) => (
+                <ErrorSummary.Item key={steg.href} href={steg.href}>
+                  {t(steg.title)}
+                </ErrorSummary.Item>
+              ))}
+            </ErrorSummary>
+          ) : (
+            <Alert variant="error">{t("felles.feilVedInnsending")}</Alert>
+          )}
+        </div>
+      )}
     </SkjemaSteg>
   );
 }

--- a/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
+++ b/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
@@ -1,5 +1,5 @@
-import { Alert } from "@navikt/ds-react";
-import { Fragment } from "react";
+import { Alert, ErrorSummary } from "@navikt/ds-react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ArbeidstakerOgArbeidsgiverOppsummering } from "~/components/oppsummering/ArbeidstakerOgArbeidsgiverOppsummering.tsx";
@@ -17,6 +17,8 @@ import type {
 } from "~/types/melosysSkjemaTypes.ts";
 
 import { SkjemaStegLoader } from "../components/SkjemaStegLoader.tsx";
+import type { StegMedFeil } from "../stegDataGetters.ts";
+import { finnManglendeSteg } from "../stegDataGetters.ts";
 import { STEG_REKKEFOLGE } from "../stegRekkefølge.ts";
 import { isArbeidsgiverOgArbeidstakersDel } from "../types.ts";
 
@@ -37,10 +39,30 @@ function OppsummeringStegContent({
   const data = skjema.data;
   const { t } = useTranslation();
   const { definisjon } = useSkjemaDefinisjon();
+  const [valideringsfeil, setValideringsfeil] = useState<StegMedFeil[]>([]);
+  const [harInnsendingFeil, setHarInnsendingFeil] = useState(false);
+  const errorRef = useRef<HTMLDivElement>(null);
 
   const seksjoner = resolveSeksjoner(data, definisjon as SkjemaDefinisjonDto);
 
   const erKombinertSkjema = isArbeidsgiverOgArbeidstakersDel(data);
+  const harFeil = valideringsfeil.length > 0 || harInnsendingFeil;
+
+  useEffect(() => {
+    if (harFeil) {
+      errorRef.current?.scrollIntoView({ behavior: "smooth" });
+      errorRef.current?.focus();
+    }
+  }, [harFeil]);
+
+  const kanSendeInn = () => {
+    const stegMedFeil = finnManglendeSteg(skjema, stegRekkefolge, skjema.id);
+
+    setValideringsfeil(stegMedFeil);
+    setHarInnsendingFeil(false);
+
+    return stegMedFeil.length === 0;
+  };
 
   return (
     <SkjemaSteg
@@ -48,8 +70,29 @@ function OppsummeringStegContent({
         stepKey: StegKey.OPPSUMMERING,
         skjema,
       }}
-      nesteKnapp={<SendInnSkjemaKnapp skjemaId={skjema.id} />}
+      nesteKnapp={
+        <SendInnSkjemaKnapp
+          skjemaId={skjema.id}
+          onBeforeSubmit={kanSendeInn}
+          onSubmitError={() => setHarInnsendingFeil(true)}
+        />
+      }
     >
+      {harFeil && (
+        <div ref={errorRef} className="mt-4" tabIndex={-1}>
+          {valideringsfeil.length > 0 ? (
+            <ErrorSummary heading={t("felles.stegManglerUtfylling")}>
+              {valideringsfeil.map((steg) => (
+                <ErrorSummary.Item key={steg.href} href={steg.href}>
+                  {t(steg.title)}
+                </ErrorSummary.Item>
+              ))}
+            </ErrorSummary>
+          ) : (
+            <Alert variant="error">{t("felles.feilVedInnsending")}</Alert>
+          )}
+        </div>
+      )}
       <ArbeidstakerOgArbeidsgiverOppsummering skjema={skjema} />
       {seksjoner.map(({ seksjonNavn, seksjon, data, stegKey }) => {
         const steg = stegRekkefolge.find((s) => s.key === stegKey);

--- a/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
+++ b/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
@@ -17,10 +17,11 @@ import type {
 } from "~/types/melosysSkjemaTypes.ts";
 
 import { SkjemaStegLoader } from "../components/SkjemaStegLoader.tsx";
-import type { StegMedFeil } from "../stegDataGetters.ts";
 import { finnManglendeSteg } from "../stegDataGetters.ts";
 import { STEG_REKKEFOLGE } from "../stegRekkefølge.ts";
 import { isArbeidsgiverOgArbeidstakersDel } from "../types.ts";
+
+type ManglendeSteg = ReturnType<typeof finnManglendeSteg>;
 
 export function OppsummeringSteg({ id }: { id: string }) {
   return (
@@ -39,14 +40,14 @@ function OppsummeringStegContent({
   const data = skjema.data;
   const { t } = useTranslation();
   const { definisjon } = useSkjemaDefinisjon();
-  const [valideringsfeil, setValideringsfeil] = useState<StegMedFeil[]>([]);
+  const [manglendeSteg, setManglendeSteg] = useState<ManglendeSteg>([]);
   const [harInnsendingFeil, setHarInnsendingFeil] = useState(false);
   const errorRef = useRef<HTMLDivElement>(null);
 
   const seksjoner = resolveSeksjoner(data, definisjon as SkjemaDefinisjonDto);
 
   const erKombinertSkjema = isArbeidsgiverOgArbeidstakersDel(data);
-  const harFeil = valideringsfeil.length > 0 || harInnsendingFeil;
+  const harFeil = manglendeSteg.length > 0 || harInnsendingFeil;
 
   useEffect(() => {
     if (harFeil) {
@@ -56,12 +57,12 @@ function OppsummeringStegContent({
   }, [harFeil]);
 
   const kanSendeInn = () => {
-    const stegMedFeil = finnManglendeSteg(skjema, stegRekkefolge, skjema.id);
+    const manglendeSteg = finnManglendeSteg(skjema, stegRekkefolge, skjema.id);
 
-    setValideringsfeil(stegMedFeil);
+    setManglendeSteg(manglendeSteg);
     setHarInnsendingFeil(false);
 
-    return stegMedFeil.length === 0;
+    return manglendeSteg.length === 0;
   };
 
   return (
@@ -109,9 +110,9 @@ function OppsummeringStegContent({
       />
       {harFeil && (
         <div ref={errorRef} className="mt-4" tabIndex={-1}>
-          {valideringsfeil.length > 0 ? (
+          {manglendeSteg.length > 0 ? (
             <ErrorSummary heading={t("felles.stegManglerUtfylling")}>
-              {valideringsfeil.map((steg) => (
+              {manglendeSteg.map((steg) => (
                 <ErrorSummary.Item key={steg.href} href={steg.href}>
                   {t(steg.title)}
                 </ErrorSummary.Item>

--- a/app/src/pages/skjema/stegDataGetters.ts
+++ b/app/src/pages/skjema/stegDataGetters.ts
@@ -18,7 +18,7 @@ import type {
 } from "~/types/melosysSkjemaTypes.ts";
 import { Skjemadel } from "~/types/melosysSkjemaTypes.ts";
 
-export interface StegMedFeil {
+export interface ManglendeSteg {
   title: string;
   href: string;
 }
@@ -214,7 +214,7 @@ export function finnManglendeSteg(
   skjema: UtsendtArbeidstakerSkjemaDto,
   stegRekkefolge: StegRekkefolgeItem[],
   skjemaId: string,
-): StegMedFeil[] {
+): ManglendeSteg[] {
   return stegRekkefolge
     .filter((steg) => !harUtfyltSteg(skjema, steg.key))
     .map((steg) => ({

--- a/app/src/pages/skjema/stegDataGetters.ts
+++ b/app/src/pages/skjema/stegDataGetters.ts
@@ -1,3 +1,5 @@
+import { StegKey } from "~/constants/stegKeys.ts";
+import type { StegRekkefolgeItem } from "~/pages/skjema/components/Fremgangsindikator.tsx";
 import type {
   ArbeidsgiverensVirksomhetINorgeDto,
   ArbeidssituasjonDto,
@@ -15,6 +17,11 @@ import type {
   VedleggValgDto,
 } from "~/types/melosysSkjemaTypes.ts";
 import { Skjemadel } from "~/types/melosysSkjemaTypes.ts";
+
+export interface StegMedFeil {
+  title: string;
+  href: string;
+}
 
 // ---------------------------------------------------------------------------
 // Arbeidsgiver-steg (ARBEIDSGIVERS_DEL / ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL)
@@ -156,4 +163,62 @@ export function getVedleggValg(
   skjema: UtsendtArbeidstakerSkjemaDto,
 ): VedleggValgDto | undefined {
   return skjema.data.vedlegg;
+}
+
+function harUtfyltSteg(
+  skjema: UtsendtArbeidstakerSkjemaDto,
+  stegKey: StegKey,
+): boolean {
+  switch (stegKey) {
+    case StegKey.UTSENDINGSPERIODE_OG_LAND: {
+      return Boolean(getUtsendingsperiodeOgLand(skjema));
+    }
+    case StegKey.ARBEIDSGIVERENS_VIRKSOMHET_I_NORGE: {
+      return Boolean(getArbeidsgiverensVirksomhetINorge(skjema));
+    }
+    case StegKey.UTENLANDSOPPDRAGET: {
+      return Boolean(getUtenlandsoppdraget(skjema));
+    }
+    case StegKey.ARBEIDSSTED_I_UTLANDET: {
+      return Boolean(getArbeidsstedIUtlandet(skjema));
+    }
+    case StegKey.ARBEIDSTAKERENS_LONN: {
+      return Boolean(getArbeidstakerensLonn(skjema));
+    }
+    case StegKey.ARBEIDSSITUASJON: {
+      return Boolean(getArbeidssituasjon(skjema));
+    }
+    case StegKey.SKATTEFORHOLD_OG_INNTEKT: {
+      return Boolean(getSkatteforholdOgInntekt(skjema));
+    }
+    case StegKey.FAMILIEMEDLEMMER: {
+      return Boolean(getFamiliemedlemmer(skjema));
+    }
+    case StegKey.TILLEGGSOPPLYSNINGER: {
+      return Boolean(getTilleggsopplysninger(skjema));
+    }
+    case StegKey.VEDLEGG: {
+      return Boolean(getVedleggValg(skjema));
+    }
+    case StegKey.OPPSUMMERING: {
+      return true;
+    }
+  }
+}
+
+/**
+ * Finner top-level steg som ikke er fylt ut før innsending.
+ * Returnerer steg i visningsrekkefølge med tittel og rute.
+ */
+export function finnManglendeSteg(
+  skjema: UtsendtArbeidstakerSkjemaDto,
+  stegRekkefolge: StegRekkefolgeItem[],
+  skjemaId: string,
+): StegMedFeil[] {
+  return stegRekkefolge
+    .filter((steg) => !harUtfyltSteg(skjema, steg.key))
+    .map((steg) => ({
+      title: steg.title,
+      href: steg.route.replace("$id", skjemaId),
+    }));
 }

--- a/app/tests/e2e/pages/skjema/oppsummering-steg.page.ts
+++ b/app/tests/e2e/pages/skjema/oppsummering-steg.page.ts
@@ -426,6 +426,38 @@ export class OppsummeringStegPage {
     await responsePromise;
   }
 
+  async sendInnAndExpectNoPost() {
+    const requestPromise = this.page
+      .waitForRequest(
+        (request) =>
+          request
+            .url()
+            .includes(
+              `/api/skjema/utsendt-arbeidstaker/${this.skjema.id}/send-inn`,
+            ) && request.method() === "POST",
+        { timeout: 500 },
+      )
+      .then(() => true)
+      .catch(() => false);
+
+    await this.sendSoknadButton.click();
+
+    await expect(await requestPromise).toBe(false);
+  }
+
+  async assertManglendeStegVises(steg: Array<{ navn: string; href: string }>) {
+    await expect(
+      this.page.getByText(nb.translation.felles.stegManglerUtfylling),
+    ).toBeVisible();
+
+    for (const { navn, href } of steg) {
+      await expect(this.page.getByRole("link", { name: navn })).toHaveAttribute(
+        "href",
+        href,
+      );
+    }
+  }
+
   async assertNavigatedToKvittering() {
     await expect(this.page).toHaveURL(`/skjema/${this.skjema.id}/kvittering`);
   }

--- a/app/tests/e2e/specs/skjema/oppsummering.spec.ts
+++ b/app/tests/e2e/specs/skjema/oppsummering.spec.ts
@@ -1,3 +1,4 @@
+import { nb } from "~/i18n/nb";
 import {
   ArbeidsgiverensVirksomhetINorgeDto,
   ArbeidssituasjonDto,
@@ -74,6 +75,7 @@ test.describe("Oppsummering", () => {
           familiemedlemmer: familiemedlemmerData,
           skatteforholdOgInntekt: skatteforholdOgInntektData,
           tilleggsopplysninger: tilleggsopplysningerData,
+          vedlegg: { harAnnenDokumentasjon: false },
         } as UtsendtArbeidstakerSkjemaDto["data"],
       });
 
@@ -137,6 +139,11 @@ test.describe("Oppsummering", () => {
       arbeidsgiverBetalerAllLonnOgNaturaytelserIUtsendingsperioden: true,
     };
 
+    const utsendingsperiodeOgLandData = {
+      utsendelseLand: formFieldValues.utsendelseLand.value,
+      utsendelsePeriode: formFieldValues.periode,
+    };
+
     const tilleggsopplysningerData: TilleggsopplysningerDto = {
       harFlereOpplysningerTilSoknaden: false,
     };
@@ -161,7 +168,9 @@ test.describe("Oppsummering", () => {
           utenlandsoppdraget: utenlandsoppdragetData,
           arbeidsstedIUtlandet: arbeidsstedIUtlandetData,
           arbeidstakerensLonn: arbeidstakerensLonnData,
+          utsendingsperiodeOgLand: utsendingsperiodeOgLandData,
           tilleggsopplysninger: tilleggsopplysningerData,
+          vedlegg: { harAnnenDokumentasjon: false },
         } as UtsendtArbeidstakerSkjemaDto["data"],
       });
 
@@ -191,6 +200,41 @@ test.describe("Oppsummering", () => {
 
       await oppsummeringStegPage.sendInnAndExpectPost();
       await oppsummeringStegPage.assertNavigatedToKvittering();
+    });
+
+    test("viser feillenke og sender ikke inn når et steg mangler utfylling", async ({
+      page,
+    }) => {
+      await mockFetchSkjema(page, {
+        ...testArbeidsgiverSkjema,
+        data: {
+          type: "UTSENDT_ARBEIDSTAKER_ARBEIDSGIVERS_DEL",
+          utenlandsoppdraget: utenlandsoppdragetData,
+          arbeidsstedIUtlandet: arbeidsstedIUtlandetData,
+          arbeidstakerensLonn: arbeidstakerensLonnData,
+          tilleggsopplysninger: tilleggsopplysningerData,
+        } as UtsendtArbeidstakerSkjemaDto["data"],
+      });
+
+      const oppsummeringStegPage = new OppsummeringStegPage(
+        page,
+        testArbeidsgiverSkjema,
+      );
+
+      await oppsummeringStegPage.goto();
+      await oppsummeringStegPage.assertIsVisible();
+
+      await oppsummeringStegPage.sendInnAndExpectNoPost();
+      await oppsummeringStegPage.assertManglendeStegVises([
+        {
+          navn: nb.translation.arbeidsgiverensVirksomhetINorgeSteg.tittel,
+          href: `/skjema/${testArbeidsgiverSkjema.id}/arbeidsgiverens-virksomhet-i-norge`,
+        },
+        {
+          navn: nb.translation.vedleggSteg.tittel,
+          href: `/skjema/${testArbeidsgiverSkjema.id}/vedlegg`,
+        },
+      ]);
     });
   });
 
@@ -269,6 +313,7 @@ test.describe("Oppsummering", () => {
           arbeidstakersData,
           utsendingsperiodeOgLand: utsendingsperiodeOgLandData,
           tilleggsopplysninger: tilleggsopplysningerData,
+          vedlegg: { harAnnenDokumentasjon: false },
         } as UtsendtArbeidstakerSkjemaDto["data"],
       });
 


### PR DESCRIPTION
Legger til validering av ufullstendige steg og beskrivende feilmeldinger i oppsummeringssteget før innsending av søknad.

Tidligere fikk brukeren kun en generisk toast-feilmelding ved feil. Nå valideres det at alle påkrevde steg er fylt ut før innsending, og feilmeldinger vises inline med lenker til stegene som mangler utfylling.
[MELOSYS-8081](https://jira.adeo.no/browse/MELOSYS-8081)

- Validering av manglende steg før innsending med `ErrorSummary` fra Aksel
- Beskrivende feilmelding med lenker til ufullstendige steg
- Egen feilmelding ved API-feil under innsending (erstatter generisk toast)
- Ny hjelpefunksjon `finnManglendeSteg` i `stegDataGetters.ts`
- E2E-tester for validering av manglende steg

## Testing
- [x] E2E-tester for feilvisning ved manglende steg
- [x] Manuell testing lokalt

