### PR TITLE
8083 Disable sprakvalg til oversettelser er godkjent

### DIFF
--- a/app/src/components/AppHeader.tsx
+++ b/app/src/components/AppHeader.tsx
@@ -9,8 +9,9 @@ export function AppHeader() {
   const { t } = useTranslation();
   const representasjonskontekst = useRepresentasjonskontekst();
 
+  // Fjern paddingBlock i MELOSYS-8094
   return (
-    <HStack align="center" justify="space-between">
+    <HStack align="center" justify="space-between" paddingBlock="space-8">
       <Heading level="1" size="medium">
         {t("appHeader.tittel")}
       </Heading>

--- a/app/src/components/KontekstVelger.tsx
+++ b/app/src/components/KontekstVelger.tsx
@@ -33,6 +33,11 @@ function MaalformValg() {
     await i18n.changeLanguage(code);
   };
 
+  // Fjern i MELOSYS-8094
+  if (SUPPORTED_LANGUAGES.length <= 1) {
+    return null;
+  }
+
   return (
     <HStack align="center" gap="space-8">
       <GlobeIcon aria-hidden fontSize="1.5rem" />
@@ -179,8 +184,12 @@ export function KontekstVelger() {
             onVelg={() => setIsOpen(false)}
             visOverskrift={false}
           />
-          <hr className="my-4 border-border-subtle" />
-          <MaalformValg />
+          {SUPPORTED_LANGUAGES.length > 1 && (
+            <>
+              <hr className="my-4 border-border-subtle" />
+              <MaalformValg />
+            </>
+          )}
         </Popover.Content>
       </Popover>
     </>

--- a/app/src/components/MaalformVelger.tsx
+++ b/app/src/components/MaalformVelger.tsx
@@ -17,6 +17,11 @@ export function MaalformVelger() {
     await i18n.changeLanguage(code);
   };
 
+  // Fjern i MELOSYS-8094
+  if (SUPPORTED_LANGUAGES.length <= 1) {
+    return null;
+  }
+
   return (
     <Dropdown>
       <Button as={Dropdown.Toggle} variant="tertiary-neutral">

--- a/app/src/utils/languages.ts
+++ b/app/src/utils/languages.ts
@@ -7,5 +7,7 @@ export interface Language {
 
 export const SUPPORTED_LANGUAGES: Language[] = [
   { code: "nb", label: "Norsk" },
-  { code: "en", label: "English" },
+  // Aktiver naar oversettelsene er offisielt godkjent (MELOSYS-8094)
+  // { code: "en", label: "English" },
+  // { code: "nn", label: "Nynorsk" },
 ];


### PR DESCRIPTION
Disabler språkvalg (engelsk og nynorsk) i søknadsskjemaet
midlertidig, til oversettelsene er offisielt godkjent.

Oversettelsene til engelsk og nynorsk må offisielt godkjennes før
brukere kan få tilgang til skjemaet på disse språkene i prod.
Siden godkjenningene ikke er på plass før prodsetting, disables
språkvalget midlertidig.
[MELOSYS-8083](https://jira.adeo.no/browse/MELOSYS-8083)

- Fjernet engelsk fra `SUPPORTED_LANGUAGES` (kommentert ut med referanse til oppgave som enabler språk)
- Språkvelger-komponentene (`MaalformVelger`, `MaalformValg`) skjules når kun étt språk er tilgjengelig
- Separator i `KontekstVelger`-popover skjules også
- Lagt inn midlertidig fiks så header har samme størrelse

## Testing
- [x] Manuell testing lokalt
