### PR TITLE
8086 Erstatt toast og stille feil med persistent Alert

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,6 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-hook-form": "7.75.0",
-    "react-hot-toast": "2.6.0",
     "react-i18next": "17.0.7",
     "tailwindcss": "^4.3.0",
     "zod": "4.4.3"

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       react-hook-form:
         specifier: 7.75.0
         version: 7.75.0(react@19.2.6)
-      react-hot-toast:
-        specifier: 2.6.0
-        version: 2.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-i18next:
         specifier: 17.0.7
         version: 17.0.7(i18next@26.1.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
@@ -661,6 +658,9 @@ packages:
       '@types/react': ^17.0.30 || ^18 || ^19
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@navikt/ds-tailwind@8.10.5':
     resolution: {integrity: sha512-eA2KQEYCYtonxzKbPxaoc7JSGtMplAy3QNKaEnjyB1hAvc17ZyHTbxzBhColmiYi6jm7HMXpUVlzTfluHrJdRw==, tarball: https://npm.pkg.github.com/download/@navikt/ds-tailwind/8.10.5/da49e54241cd74793b93c190302e449def544a3e}
@@ -677,6 +677,9 @@ packages:
     peerDependencies:
       html-react-parser: '>=5.x'
       react: '>=17.x'
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   '@oxc-project/types@0.129.0':
     resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
@@ -1652,11 +1655,6 @@ packages:
     resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
-  goober@2.1.18:
-    resolution: {integrity: sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==}
-    peerDependencies:
-      csstype: ^3.0.10
-
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -2055,13 +2053,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
-
-  react-hot-toast@2.6.0:
-    resolution: {integrity: sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: '>=16'
-      react-dom: '>=16'
 
   react-i18next@17.0.7:
     resolution: {integrity: sha512-rwtPXsb/zwzDafN+gytcjF5YnqGQQIRmCQ6DctBC1VSipRB8GD/MWEVrFP42vjMyuYydxWxM8CZRt+yiNuuoHg==}
@@ -3030,11 +3021,12 @@ snapshots:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@navikt/aksel-icons': 8.10.5
       '@navikt/ds-tokens': 8.10.5
-      '@types/react': 19.2.14
       date-fns: 4.1.0
       react: 19.2.6
       react-day-picker: 9.14.0(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@navikt/ds-tailwind@8.10.5': {}
 
@@ -3047,6 +3039,7 @@ snapshots:
       csp-header: 6.3.1
       html-react-parser: 5.2.17(@types/react@19.2.14)(react@19.2.6)
       js-cookie: 3.0.5
+    optionalDependencies:
       react: 19.2.6
 
   '@oxc-project/types@0.129.0': {}
@@ -4084,10 +4077,6 @@ snapshots:
 
   globals@17.6.0: {}
 
-  goober@2.1.18(csstype@3.2.3):
-    dependencies:
-      csstype: 3.2.3
-
   graceful-fs@4.2.11: {}
 
   html-dom-parser@5.1.8:
@@ -4443,13 +4432,6 @@ snapshots:
   react-hook-form@7.75.0(react@19.2.6):
     dependencies:
       react: 19.2.6
-
-  react-hot-toast@2.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
-    dependencies:
-      csstype: 3.2.3
-      goober: 2.1.18(csstype@3.2.3)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
 
   react-i18next@17.0.7(i18next@26.1.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
     dependencies:

--- a/app/src/components/oppsummering/VedleggOppsummering.tsx
+++ b/app/src/components/oppsummering/VedleggOppsummering.tsx
@@ -42,7 +42,10 @@ export function VedleggOppsummering({
     let cancelled = false;
     hentVedlegg(skjemaId)
       .then((v) => {
-        if (!cancelled) setVedlegg(v);
+        if (!cancelled) {
+          setVedlegg(v);
+          setHentVedleggFeil(false);
+        }
       })
       .catch(() => {
         if (!cancelled) setHentVedleggFeil(true);

--- a/app/src/components/oppsummering/VedleggOppsummering.tsx
+++ b/app/src/components/oppsummering/VedleggOppsummering.tsx
@@ -69,7 +69,7 @@ export function VedleggOppsummering({
       <FormSummary.Answers>
         {hentVedleggFeil && (
           <FormSummary.Answer>
-            <Alert size="small" variant="error">
+            <Alert role="alert" size="small" variant="error">
               {t("vedleggSteg.feilVedHentingAvVedlegg")}
             </Alert>
           </FormSummary.Answer>

--- a/app/src/components/oppsummering/VedleggOppsummering.tsx
+++ b/app/src/components/oppsummering/VedleggOppsummering.tsx
@@ -1,4 +1,9 @@
-import { BodyShort, FormSummary, Link as DsLink } from "@navikt/ds-react";
+import {
+  Alert,
+  BodyShort,
+  FormSummary,
+  Link as DsLink,
+} from "@navikt/ds-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -23,6 +28,7 @@ export function VedleggOppsummering({
   const { t } = useTranslation();
   const { getFelt } = useSkjemaDefinisjon();
   const [vedlegg, setVedlegg] = useState<VedleggDto[]>([]);
+  const [hentVedleggFeil, setHentVedleggFeil] = useState(false);
 
   const harAnnenDokumentasjonFelt = getFelt(
     "vedleggArbeidstaker",
@@ -38,7 +44,9 @@ export function VedleggOppsummering({
       .then((v) => {
         if (!cancelled) setVedlegg(v);
       })
-      .catch(() => {});
+      .catch(() => {
+        if (!cancelled) setHentVedleggFeil(true);
+      });
     return () => {
       cancelled = true;
     };
@@ -59,6 +67,13 @@ export function VedleggOppsummering({
         </FormSummary.Heading>
       </FormSummary.Header>
       <FormSummary.Answers>
+        {hentVedleggFeil && (
+          <FormSummary.Answer>
+            <Alert size="small" variant="error">
+              {t("vedleggSteg.feilVedHentingAvVedlegg")}
+            </Alert>
+          </FormSummary.Answer>
+        )}
         {svarLabel !== undefined && (
           <FormSummary.Answer>
             <FormSummary.Label>

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -202,6 +202,10 @@ export const en = {
       duMaSvarePaOmDuHarAnnenDokumentasjon:
         "You must answer whether you have other documentation you wish to attach",
       duMaLasteOppMinstEttVedlegg: "You must upload at least one attachment",
+      feilVedHentingAvVedlegg:
+        "Could not load attachments. Please try again later.",
+      feilVedSlettingAvVedlegg:
+        "Could not delete the attachment. Please try again.",
     },
     skatteforholdOgInntektSteg: {
       tittel: "Tax conditions and income",

--- a/app/src/i18n/nb.ts
+++ b/app/src/i18n/nb.ts
@@ -173,6 +173,8 @@ export const nb = {
       duMaSvarePaOmDuHarAnnenDokumentasjon:
         "Du må svare på om du har annen dokumentasjon du ønsker å legge ved",
       duMaLasteOppMinstEttVedlegg: "Du må laste opp minst ett vedlegg",
+      feilVedHentingAvVedlegg: "Kunne ikke hente vedlegg. Prøv igjen senere.",
+      feilVedSlettingAvVedlegg: "Kunne ikke slette vedlegget. Prøv igjen.",
     },
     arbeidssituasjonSteg: {
       tittel: "Arbeidssituasjon",

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -10,7 +10,6 @@ import {
 import i18n from "i18next";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { Toaster } from "react-hot-toast";
 import { initReactI18next } from "react-i18next";
 
 import { logSkjemaDefinisjonValidation } from "~/utils/validateSkjemaDefinisjon";
@@ -78,7 +77,6 @@ declare module "@tanstack/react-router" {
 createRoot(document.querySelector("#root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <Toaster />
       <RouterProvider router={router} />
     </QueryClientProvider>
   </StrictMode>,

--- a/app/src/pages/skjema/arbeidsgiverens-virksomhet-i-norge/ArbeidsgiverensVirksomhetINorgeSteg.tsx
+++ b/app/src/pages/skjema/arbeidsgiverens-virksomhet-i-norge/ArbeidsgiverensVirksomhetINorgeSteg.tsx
@@ -2,8 +2,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
-import { toast } from "react-hot-toast";
-import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
 import { RadioGroupJaNeiFormPart } from "~/components/RadioGroupJaNeiFormPart.tsx";
@@ -42,7 +40,6 @@ function ArbeidsgiverensVirksomhetINorgeStegContent({
   const stegRekkefolge = STEG_REKKEFOLGE[skjema.metadata.skjemadel];
   const stegData = getArbeidsgiverensVirksomhetINorge(skjema);
   const navigate = useNavigate();
-  const { t } = useTranslation();
   const invalidateArbeidsgiverSkjemaQuery = useInvalidateSkjemaQuery();
   const { getFelt } = useSkjemaDefinisjon();
 
@@ -91,9 +88,6 @@ function ArbeidsgiverensVirksomhetINorgeStegContent({
         });
       }
     },
-    onError: () => {
-      toast.error(t("felles.feil"));
-    },
   });
 
   const onSubmit = (data: ArbeidsgiverensVirksomhetFormData) => {
@@ -108,6 +102,7 @@ function ArbeidsgiverensVirksomhetINorgeStegContent({
             stepKey: StegKey.ARBEIDSGIVERENS_VIRKSOMHET_I_NORGE,
             skjema,
           }}
+          isSubmitError={registerVirksomhetMutation.isError}
           nesteKnapp={
             <NesteStegKnapp loading={registerVirksomhetMutation.isPending} />
           }

--- a/app/src/pages/skjema/arbeidssituasjon/ArbeidssituasjonSteg.tsx
+++ b/app/src/pages/skjema/arbeidssituasjon/ArbeidssituasjonSteg.tsx
@@ -3,7 +3,6 @@ import { Alert, BodyLong, Heading, Textarea } from "@navikt/ds-react";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
-import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
@@ -100,9 +99,6 @@ function ArbeidssituasjonStegContent({
         });
       }
     },
-    onError: () => {
-      toast.error(t("felles.feil"));
-    },
   });
 
   const onSubmit = (data: ArbeidssituasjonFormData) => {
@@ -117,6 +113,7 @@ function ArbeidssituasjonStegContent({
             stepKey: StegKey.ARBEIDSSITUASJON,
             skjema,
           }}
+          isSubmitError={postArbeidssituasjonMutation.isError}
           nesteKnapp={
             <NesteStegKnapp loading={postArbeidssituasjonMutation.isPending} />
           }

--- a/app/src/pages/skjema/arbeidssted-i-utlandet/ArbeidsstedIUtlandetSteg.tsx
+++ b/app/src/pages/skjema/arbeidssted-i-utlandet/ArbeidsstedIUtlandetSteg.tsx
@@ -3,7 +3,6 @@ import { Select } from "@navikt/ds-react";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
-import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
@@ -85,9 +84,6 @@ function ArbeidsstedIUtlandetStegContent({
         });
       }
     },
-    onError: () => {
-      toast.error(t("felles.feil"));
-    },
   });
 
   const onSubmit = (data: ArbeidsstedIUtlandetFormData) => {
@@ -102,6 +98,7 @@ function ArbeidsstedIUtlandetStegContent({
             stepKey: StegKey.ARBEIDSSTED_I_UTLANDET,
             skjema,
           }}
+          isSubmitError={registerArbeidsstedMutation.isError}
           nesteKnapp={
             <NesteStegKnapp loading={registerArbeidsstedMutation.isPending} />
           }

--- a/app/src/pages/skjema/arbeidstakerens-lonn/ArbeidstakerensLonnSteg.tsx
+++ b/app/src/pages/skjema/arbeidstakerens-lonn/ArbeidstakerensLonnSteg.tsx
@@ -2,7 +2,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
-import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
@@ -85,9 +84,6 @@ function ArbeidstakerensLonnStegContent({
         });
       }
     },
-    onError: () => {
-      toast.error(t("felles.feil"));
-    },
   });
 
   const onSubmit = (data: ArbeidstakerensLonnFormData) => {
@@ -125,6 +121,7 @@ function ArbeidstakerensLonnStegContent({
             stepKey: StegKey.ARBEIDSTAKERENS_LONN,
             skjema,
           }}
+          isSubmitError={registerArbeidstakerLonnMutation.isError}
           nesteKnapp={
             <NesteStegKnapp
               loading={registerArbeidstakerLonnMutation.isPending}

--- a/app/src/pages/skjema/components/AvbrytOgSlettKnapp.tsx
+++ b/app/src/pages/skjema/components/AvbrytOgSlettKnapp.tsx
@@ -50,7 +50,7 @@ export function AvbrytOgSlettKnapp({
         <Modal.Body>
           <BodyLong>{t("felles.alleOpplysningerVilBliSlettet")}</BodyLong>
           {slettUtkastMutation.isError && (
-            <Alert className="mt-4" size="small" variant="error">
+            <Alert className="mt-4" role="alert" size="small" variant="error">
               {t("felles.feil")}
             </Alert>
           )}

--- a/app/src/pages/skjema/components/AvbrytOgSlettKnapp.tsx
+++ b/app/src/pages/skjema/components/AvbrytOgSlettKnapp.tsx
@@ -1,8 +1,7 @@
-import { BodyLong, Button, Modal } from "@navikt/ds-react";
+import { Alert, BodyLong, Button, Modal } from "@navikt/ds-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
-import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 
 import { slettUtkast } from "~/httpClients/melsosysSkjemaApiClient.ts";
@@ -28,9 +27,6 @@ export function AvbrytOgSlettKnapp({
       void queryClient.invalidateQueries({ queryKey: ["utkast"] });
       void navigate({ to: "/oversikt", search: representasjonskontekst });
     },
-    onError: () => {
-      toast.error(t("felles.feil"));
-    },
   });
 
   return (
@@ -53,6 +49,11 @@ export function AvbrytOgSlettKnapp({
       >
         <Modal.Body>
           <BodyLong>{t("felles.alleOpplysningerVilBliSlettet")}</BodyLong>
+          {slettUtkastMutation.isError && (
+            <Alert className="mt-4" size="small" variant="error">
+              {t("felles.feil")}
+            </Alert>
+          )}
         </Modal.Body>
         <Modal.Footer>
           <Button

--- a/app/src/pages/skjema/components/SendInnSkjemaKnapp.tsx
+++ b/app/src/pages/skjema/components/SendInnSkjemaKnapp.tsx
@@ -54,7 +54,7 @@ export function SendInnSkjemaKnapp({ skjemaId }: SendInnSkjemaKnappProps) {
   return (
     <>
       {sendInnSkjemaMutation.isError && (
-        <Alert className="mb-4" size="small" variant="error">
+        <Alert className="mb-4" role="alert" size="small" variant="error">
           {t("felles.feil")}
         </Alert>
       )}

--- a/app/src/pages/skjema/components/SendInnSkjemaKnapp.tsx
+++ b/app/src/pages/skjema/components/SendInnSkjemaKnapp.tsx
@@ -1,5 +1,5 @@
 import { PaperplaneIcon } from "@navikt/aksel-icons";
-import { Alert, Button } from "@navikt/ds-react";
+import { Button } from "@navikt/ds-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
@@ -65,22 +65,15 @@ export function SendInnSkjemaKnapp({
   };
 
   return (
-    <>
-      {sendInnSkjemaMutation.isError && (
-        <Alert className="mb-4" role="alert" size="small" variant="error">
-          {t("felles.feil")}
-        </Alert>
-      )}
-      <Button
-        icon={<PaperplaneIcon />}
-        iconPosition="right"
-        loading={sendInnSkjemaMutation.isPending}
-        onClick={handleClick}
-        type="button"
-        variant="primary"
-      >
-        {t("felles.sendSoknad")}
-      </Button>
-    </>
+    <Button
+      icon={<PaperplaneIcon />}
+      iconPosition="right"
+      loading={sendInnSkjemaMutation.isPending}
+      onClick={handleClick}
+      type="button"
+      variant="primary"
+    >
+      {t("felles.sendSoknad")}
+    </Button>
   );
 }

--- a/app/src/pages/skjema/components/SendInnSkjemaKnapp.tsx
+++ b/app/src/pages/skjema/components/SendInnSkjemaKnapp.tsx
@@ -1,8 +1,7 @@
 import { PaperplaneIcon } from "@navikt/aksel-icons";
-import { Button } from "@navikt/ds-react";
+import { Alert, Button } from "@navikt/ds-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -46,9 +45,6 @@ export function SendInnSkjemaKnapp({ skjemaId }: SendInnSkjemaKnappProps) {
         params: { id: response.skjemaId },
       });
     },
-    onError: () => {
-      toast.error(t("felles.feil"));
-    },
   });
 
   const handleClick = () => {
@@ -56,15 +52,22 @@ export function SendInnSkjemaKnapp({ skjemaId }: SendInnSkjemaKnappProps) {
   };
 
   return (
-    <Button
-      icon={<PaperplaneIcon />}
-      iconPosition="right"
-      loading={sendInnSkjemaMutation.isPending}
-      onClick={handleClick}
-      type="button"
-      variant="primary"
-    >
-      {t("felles.sendSoknad")}
-    </Button>
+    <>
+      {sendInnSkjemaMutation.isError && (
+        <Alert className="mb-4" size="small" variant="error">
+          {t("felles.feil")}
+        </Alert>
+      )}
+      <Button
+        icon={<PaperplaneIcon />}
+        iconPosition="right"
+        loading={sendInnSkjemaMutation.isPending}
+        onClick={handleClick}
+        type="button"
+        variant="primary"
+      >
+        {t("felles.sendSoknad")}
+      </Button>
+    </>
   );
 }

--- a/app/src/pages/skjema/components/SkjemaSteg.tsx
+++ b/app/src/pages/skjema/components/SkjemaSteg.tsx
@@ -82,7 +82,7 @@ export function SkjemaSteg({
       </Heading>
       {isSubmitError && (
         <Alert className="mt-4" role="alert" size="small" variant="error">
-          {t("felles.feil")}
+          {t("felles.feilVedInnsending")}
         </Alert>
       )}
       {children}

--- a/app/src/pages/skjema/components/SkjemaSteg.tsx
+++ b/app/src/pages/skjema/components/SkjemaSteg.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeftIcon } from "@navikt/aksel-icons";
 import {
+  Alert,
   BodyShort,
   Button,
   Heading,
@@ -34,9 +35,15 @@ interface SkjemaStegProps {
   config: StegConfig;
   nesteKnapp: ReactNode;
   children?: ReactNode;
+  isSubmitError?: boolean;
 }
 
-export function SkjemaSteg({ config, nesteKnapp, children }: SkjemaStegProps) {
+export function SkjemaSteg({
+  config,
+  nesteKnapp,
+  children,
+  isSubmitError,
+}: SkjemaStegProps) {
   const { i18n, t } = useTranslation();
   const { skjema } = config;
   const stegRekkefolge = STEG_REKKEFOLGE[skjema.metadata.skjemadel];
@@ -73,6 +80,11 @@ export function SkjemaSteg({ config, nesteKnapp, children }: SkjemaStegProps) {
           title
         )}
       </Heading>
+      {isSubmitError && (
+        <Alert className="mt-4" size="small" variant="error">
+          {t("felles.feil")}
+        </Alert>
+      )}
       {children}
       <VStack className="mt-8" gap="space-4">
         <HGrid columns={2} gap="space-12">

--- a/app/src/pages/skjema/components/SkjemaSteg.tsx
+++ b/app/src/pages/skjema/components/SkjemaSteg.tsx
@@ -81,7 +81,7 @@ export function SkjemaSteg({
         )}
       </Heading>
       {isSubmitError && (
-        <Alert className="mt-4" size="small" variant="error">
+        <Alert className="mt-4" role="alert" size="small" variant="error">
           {t("felles.feil")}
         </Alert>
       )}

--- a/app/src/pages/skjema/components/SkjemaSteg.tsx
+++ b/app/src/pages/skjema/components/SkjemaSteg.tsx
@@ -80,12 +80,12 @@ export function SkjemaSteg({
           title
         )}
       </Heading>
+      {children}
       {isSubmitError && (
         <Alert className="mt-4" role="alert" size="small" variant="error">
           {t("felles.feilVedInnsending")}
         </Alert>
       )}
-      {children}
       <VStack className="mt-8" gap="space-4">
         <HGrid columns={2} gap="space-12">
           <Button

--- a/app/src/pages/skjema/familiemedlemmer/FamiliemedlemmerSteg.tsx
+++ b/app/src/pages/skjema/familiemedlemmer/FamiliemedlemmerSteg.tsx
@@ -3,7 +3,6 @@ import { Alert, BodyLong, Link } from "@navikt/ds-react";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
-import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 
 import { RadioGroupJaNeiFormPart } from "~/components/RadioGroupJaNeiFormPart.tsx";
@@ -71,9 +70,6 @@ function FamiliemedlemmerStegContent({
         });
       }
     },
-    onError: () => {
-      toast.error(t("felles.feil"));
-    },
   });
 
   const onSubmit = (data: FamiliemedlemmerDto) => {
@@ -88,6 +84,7 @@ function FamiliemedlemmerStegContent({
             stepKey: StegKey.FAMILIEMEDLEMMER,
             skjema,
           }}
+          isSubmitError={postFamiliemedlemmerMutation.isError}
           nesteKnapp={
             <NesteStegKnapp loading={postFamiliemedlemmerMutation.isPending} />
           }

--- a/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
+++ b/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
@@ -119,7 +119,9 @@ function OppsummeringStegContent({
               ))}
             </ErrorSummary>
           ) : (
-            <Alert variant="error">{t("felles.feilVedInnsending")}</Alert>
+            <Alert role="alert" variant="error">
+              {t("felles.feilVedInnsending")}
+            </Alert>
           )}
         </div>
       )}

--- a/app/src/pages/skjema/skatteforhold-og-inntekt/SkatteforholdOgInntektSteg.tsx
+++ b/app/src/pages/skjema/skatteforhold-og-inntekt/SkatteforholdOgInntektSteg.tsx
@@ -10,7 +10,6 @@ import {
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
-import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
@@ -197,9 +196,6 @@ function SkatteforholdOgInntektStegContent({
         });
       }
     },
-    onError: () => {
-      toast.error(t("felles.feil"));
-    },
   });
 
   const onSubmit = (data: SkatteforholdOgInntektFormData) => {
@@ -230,6 +226,7 @@ function SkatteforholdOgInntektStegContent({
             stepKey: StegKey.SKATTEFORHOLD_OG_INNTEKT,
             skjema,
           }}
+          isSubmitError={postSkatteforholdMutation.isError}
           nesteKnapp={
             <NesteStegKnapp loading={postSkatteforholdMutation.isPending} />
           }

--- a/app/src/pages/skjema/tilleggsopplysninger/TilleggsopplysningerSteg.tsx
+++ b/app/src/pages/skjema/tilleggsopplysninger/TilleggsopplysningerSteg.tsx
@@ -3,8 +3,6 @@ import { Textarea } from "@navikt/ds-react";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
-import { toast } from "react-hot-toast";
-import { useTranslation } from "react-i18next";
 
 import { RadioGroupJaNeiFormPart } from "~/components/RadioGroupJaNeiFormPart.tsx";
 import { StegKey } from "~/constants/stegKeys.ts";
@@ -48,7 +46,6 @@ function TilleggsopplysningerStegContent({
   const stegRekkefolge = STEG_REKKEFOLGE[skjema.metadata.skjemadel];
   const stegData = getTilleggsopplysninger(skjema);
   const navigate = useNavigate();
-  const { t } = useTranslation();
   const translateError = useTranslateError();
   const { getFelt } = useSkjemaDefinisjon();
 
@@ -97,9 +94,6 @@ function TilleggsopplysningerStegContent({
         });
       }
     },
-    onError: () => {
-      toast.error(t("felles.feil"));
-    },
   });
 
   const onSubmit = (data: TilleggsopplysningerFormData) => {
@@ -114,6 +108,7 @@ function TilleggsopplysningerStegContent({
             stepKey: StegKey.TILLEGGSOPPLYSNINGER,
             skjema,
           }}
+          isSubmitError={postTilleggsopplysningerMutation.isError}
           nesteKnapp={
             <NesteStegKnapp
               loading={postTilleggsopplysningerMutation.isPending}

--- a/app/src/pages/skjema/utenlandsoppdraget/UtenlandsoppdragetSteg.tsx
+++ b/app/src/pages/skjema/utenlandsoppdraget/UtenlandsoppdragetSteg.tsx
@@ -4,8 +4,6 @@ import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
-import { toast } from "react-hot-toast";
-import { useTranslation } from "react-i18next";
 
 import { PeriodeFormPart } from "~/components/date/PeriodeFormPart.tsx";
 import { RadioGroupJaNeiFormPart } from "~/components/RadioGroupJaNeiFormPart.tsx";
@@ -55,7 +53,6 @@ function UtenlandsoppdragetStegContent({
   const stegRekkefolge = STEG_REKKEFOLGE[skjema.metadata.skjemadel];
   const stegData = getUtenlandsoppdraget(skjema);
   const navigate = useNavigate();
-  const { t } = useTranslation();
   const translateError = useTranslateError();
   const invalidateArbeidsgiverSkjemaQuery = useInvalidateSkjemaQuery();
   const { getFelt } = useSkjemaDefinisjon();
@@ -143,9 +140,6 @@ function UtenlandsoppdragetStegContent({
         });
       }
     },
-    onError: () => {
-      toast.error(t("felles.feil"));
-    },
   });
 
   const onSubmit = (data: UtenlandsoppdragetDto) => {
@@ -160,6 +154,7 @@ function UtenlandsoppdragetStegContent({
             stepKey: StegKey.UTENLANDSOPPDRAGET,
             skjema,
           }}
+          isSubmitError={registerUtenlandsoppdragMutation.isError}
           nesteKnapp={
             <NesteStegKnapp
               loading={registerUtenlandsoppdragMutation.isPending}

--- a/app/src/pages/skjema/utsendingsperiode-og-land/UtsendingsperiodeOgLandSteg.tsx
+++ b/app/src/pages/skjema/utsendingsperiode-og-land/UtsendingsperiodeOgLandSteg.tsx
@@ -2,8 +2,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { FormProvider, useForm } from "react-hook-form";
-import { toast } from "react-hot-toast";
-import { useTranslation } from "react-i18next";
 
 import { PeriodeFormPart } from "~/components/date/PeriodeFormPart.tsx";
 import { LandVelgerFormPart } from "~/components/LandVelgerFormPart.tsx";
@@ -40,7 +38,6 @@ function UtsendingsperiodeOgLandStegContent({
   const stegRekkefolge = STEG_REKKEFOLGE[skjema.metadata.skjemadel];
   const stegData = getUtsendingsperiodeOgLand(skjema);
   const navigate = useNavigate();
-  const { t } = useTranslation();
   const invalidateSkjemaQuery = useInvalidateSkjemaQuery();
   const { getFelt } = useSkjemaDefinisjon();
 
@@ -87,9 +84,6 @@ function UtsendingsperiodeOgLandStegContent({
         });
       }
     },
-    onError: () => {
-      toast.error(t("felles.feil"));
-    },
   });
 
   const onSubmit = (data: UtsendingsperiodeOgLandDto) => {
@@ -104,6 +98,7 @@ function UtsendingsperiodeOgLandStegContent({
             stepKey: StegKey.UTSENDINGSPERIODE_OG_LAND,
             skjema,
           }}
+          isSubmitError={registerUtsendingsperiodeOgLandMutation.isError}
           nesteKnapp={
             <NesteStegKnapp
               loading={registerUtsendingsperiodeOgLandMutation.isPending}

--- a/app/src/pages/skjema/vedlegg/VedleggSteg.tsx
+++ b/app/src/pages/skjema/vedlegg/VedleggSteg.tsx
@@ -96,7 +96,10 @@ function VedleggStegContent({
     let cancelled = false;
     hentVedlegg(skjema.id)
       .then((vedlegg) => {
-        if (!cancelled) setEksisterendeVedlegg(vedlegg);
+        if (!cancelled) {
+          setEksisterendeVedlegg(vedlegg);
+          setHentVedleggFeil(false);
+        }
       })
       .catch(() => {
         if (!cancelled) setHentVedleggFeil(true);
@@ -201,22 +204,24 @@ function VedleggStegContent({
     }
   };
 
-  const handleSlettNyItem = (itemId: string) => {
-    const item = vedleggItems.find((v) => v.id === itemId);
-    if (item?.vedleggId) {
-      slettVedlegg(skjema.id, item.vedleggId)
+  const handleSlettNyVedleggItem = (vedleggItemId: string) => {
+    const vedleggItem = vedleggItems.find((v) => v.id === vedleggItemId);
+    setSlettVedleggFeil(false);
+    if (vedleggItem?.vedleggId) {
+      slettVedlegg(skjema.id, vedleggItem.vedleggId)
         .then(() => {
-          setVedleggItems((prev) => prev.filter((v) => v.id !== itemId));
+          setVedleggItems((prev) => prev.filter((v) => v.id !== vedleggItemId));
         })
         .catch(() => {
           setSlettVedleggFeil(true);
         });
     } else {
-      setVedleggItems((prev) => prev.filter((v) => v.id !== itemId));
+      setVedleggItems((prev) => prev.filter((v) => v.id !== vedleggItemId));
     }
   };
 
   const handleSlettEksisterende = (vedleggId: string) => {
+    setSlettVedleggFeil(false);
     slettVedlegg(skjema.id, vedleggId)
       .then(() => {
         setEksisterendeVedlegg((prev) =>
@@ -301,7 +306,7 @@ function VedleggStegContent({
                     <FileUpload.Item
                       button={{
                         action: "delete",
-                        onClick: () => handleSlettNyItem(item.id),
+                        onClick: () => handleSlettNyVedleggItem(item.id),
                       }}
                       error={
                         item.status === "error" ? item.errorMessage : undefined

--- a/app/src/pages/skjema/vedlegg/VedleggSteg.tsx
+++ b/app/src/pages/skjema/vedlegg/VedleggSteg.tsx
@@ -1,11 +1,10 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { FilesPartitioned } from "@navikt/ds-react";
-import { ErrorMessage, FileUpload, VStack } from "@navikt/ds-react";
+import { Alert, ErrorMessage, FileUpload, VStack } from "@navikt/ds-react";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
-import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
@@ -70,6 +69,8 @@ function VedleggStegContent({
   const [eksisterendeVedlegg, setEksisterendeVedlegg] = useState<VedleggDto[]>(
     [],
   );
+  const [hentVedleggFeil, setHentVedleggFeil] = useState(false);
+  const [slettVedleggFeil, setSlettVedleggFeil] = useState(false);
 
   const harAnnenDokumentasjonFelt = getFelt(
     "vedleggArbeidstaker",
@@ -97,7 +98,9 @@ function VedleggStegContent({
       .then((vedlegg) => {
         if (!cancelled) setEksisterendeVedlegg(vedlegg);
       })
-      .catch(() => {});
+      .catch(() => {
+        if (!cancelled) setHentVedleggFeil(true);
+      });
     return () => {
       cancelled = true;
     };
@@ -116,9 +119,6 @@ function VedleggStegContent({
           params: { id: skjema.id },
         });
       }
-    },
-    onError: () => {
-      toast.error(t("felles.feil"));
     },
   });
 
@@ -204,7 +204,9 @@ function VedleggStegContent({
   const handleSlettNyItem = (itemId: string) => {
     const item = vedleggItems.find((v) => v.id === itemId);
     if (item?.vedleggId) {
-      slettVedlegg(skjema.id, item.vedleggId).catch(() => {});
+      slettVedlegg(skjema.id, item.vedleggId).catch(() => {
+        setSlettVedleggFeil(true);
+      });
     }
     setVedleggItems((prev) => prev.filter((v) => v.id !== itemId));
   };
@@ -216,7 +218,9 @@ function VedleggStegContent({
           prev.filter((v) => v.id !== vedleggId),
         );
       })
-      .catch(() => {});
+      .catch(() => {
+        setSlettVedleggFeil(true);
+      });
   };
 
   return (
@@ -227,10 +231,23 @@ function VedleggStegContent({
             stepKey: StegKey.VEDLEGG,
             skjema,
           }}
+          isSubmitError={postVedleggValgMutation.isError}
           nesteKnapp={
             <NesteStegKnapp loading={postVedleggValgMutation.isPending} />
           }
         >
+          {hentVedleggFeil && (
+            <Alert className="mt-4" size="small" variant="error">
+              {t("vedleggSteg.feilVedHentingAvVedlegg")}
+            </Alert>
+          )}
+
+          {slettVedleggFeil && (
+            <Alert className="mt-4" size="small" variant="error">
+              {t("vedleggSteg.feilVedSlettingAvVedlegg")}
+            </Alert>
+          )}
+
           <RadioGroupJaNeiFormPart
             className="mt-4"
             formFieldName="harAnnenDokumentasjon"

--- a/app/src/pages/skjema/vedlegg/VedleggSteg.tsx
+++ b/app/src/pages/skjema/vedlegg/VedleggSteg.tsx
@@ -237,13 +237,13 @@ function VedleggStegContent({
           }
         >
           {hentVedleggFeil && (
-            <Alert className="mt-4" size="small" variant="error">
+            <Alert className="mt-4" role="alert" size="small" variant="error">
               {t("vedleggSteg.feilVedHentingAvVedlegg")}
             </Alert>
           )}
 
           {slettVedleggFeil && (
-            <Alert className="mt-4" size="small" variant="error">
+            <Alert className="mt-4" role="alert" size="small" variant="error">
               {t("vedleggSteg.feilVedSlettingAvVedlegg")}
             </Alert>
           )}

--- a/app/src/pages/skjema/vedlegg/VedleggSteg.tsx
+++ b/app/src/pages/skjema/vedlegg/VedleggSteg.tsx
@@ -204,11 +204,16 @@ function VedleggStegContent({
   const handleSlettNyItem = (itemId: string) => {
     const item = vedleggItems.find((v) => v.id === itemId);
     if (item?.vedleggId) {
-      slettVedlegg(skjema.id, item.vedleggId).catch(() => {
-        setSlettVedleggFeil(true);
-      });
+      slettVedlegg(skjema.id, item.vedleggId)
+        .then(() => {
+          setVedleggItems((prev) => prev.filter((v) => v.id !== itemId));
+        })
+        .catch(() => {
+          setSlettVedleggFeil(true);
+        });
+    } else {
+      setVedleggItems((prev) => prev.filter((v) => v.id !== itemId));
     }
-    setVedleggItems((prev) => prev.filter((v) => v.id !== itemId));
   };
 
   const handleSlettEksisterende = (vedleggId: string) => {

--- a/app/src/utils/validateSkjemaDefinisjon.ts
+++ b/app/src/utils/validateSkjemaDefinisjon.ts
@@ -5,8 +5,6 @@
  * the static TypeScript file and the backend definition.
  */
 
-import { toast } from "react-hot-toast";
-
 import {
   SKJEMA_DEFINISJONER_A1,
   type SupportedLanguage,
@@ -197,12 +195,6 @@ export async function logSkjemaDefinisjonValidation(): Promise<void> {
     // eslint-disable-next-line no-console
     console.error(
       "\n   Kjør 'npm run sync-skjema-definisjon' for å oppdatere.",
-    );
-
-    // Vis toast i UI så utvikler ser det
-    toast.error(
-      "Skjemadefinisjon ut av sync! Kjør: npm run sync-skjema-definisjon",
-      { duration: 10_000 },
     );
   }
 }

--- a/app/tests/e2e/fixtures/api-mocks.ts
+++ b/app/tests/e2e/fixtures/api-mocks.ts
@@ -567,6 +567,32 @@ export async function mockLastOppVedlegg(
   );
 }
 
+export async function mockSlettVedlegg(page: Page, skjemaId: string) {
+  await page.route(
+    new RegExp(`/api/skjema/${skjemaId}/vedlegg/`),
+    async (route) => {
+      await (route.request().method() === "DELETE"
+        ? route.fulfill({ status: 204 })
+        : route.fallback());
+    },
+  );
+}
+
+export async function mockSlettVedleggFeil(page: Page, skjemaId: string) {
+  await page.route(
+    new RegExp(`/api/skjema/${skjemaId}/vedlegg/`),
+    async (route) => {
+      await (route.request().method() === "DELETE"
+        ? route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ message: "Internal Server Error" }),
+          })
+        : route.fallback());
+    },
+  );
+}
+
 // ============ Innsendt skjema mocks ============
 
 export async function mockInnsendtSkjema(

--- a/app/tests/e2e/fixtures/api-mocks.ts
+++ b/app/tests/e2e/fixtures/api-mocks.ts
@@ -588,6 +588,69 @@ export async function mockInnsendtSkjema(
   );
 }
 
+// ============ Feilhåndtering mocks ============
+
+export async function mockPostFamiliemedlemmerFeil(
+  page: Page,
+  skjemaId: string,
+) {
+  await page.route(
+    `/api/skjema/utsendt-arbeidstaker/${skjemaId}/familiemedlemmer`,
+    async (route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ message: "Internal Server Error" }),
+        });
+      }
+    },
+  );
+}
+
+export async function mockSendInnSkjemaFeil(page: Page, skjemaId: string) {
+  await page.route(
+    `/api/skjema/utsendt-arbeidstaker/${skjemaId}/send-inn`,
+    async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Internal Server Error" }),
+      });
+    },
+  );
+}
+
+export async function mockSlettUtkastFeil(page: Page, skjemaId: string) {
+  await page.route(
+    `/api/skjema/utsendt-arbeidstaker/${skjemaId}`,
+    async (route) => {
+      await (route.request().method() === "DELETE"
+        ? route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ message: "Internal Server Error" }),
+          })
+        : route.fallback());
+    },
+  );
+}
+
+export async function mockHentVedleggFeil(page: Page, skjemaId: string) {
+  await page.route(
+    new RegExp(`/api/skjema/${skjemaId}/vedlegg$`),
+    async (route) => {
+      await (route.request().method() === "GET"
+        ? route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ message: "Internal Server Error" }),
+          })
+        : route.fallback());
+    },
+  );
+}
+
 // ============ Oversikt composite setup ============
 
 export async function setupApiMocksForOversikt(

--- a/app/tests/e2e/pages/skjema/vedlegg-steg.page.ts
+++ b/app/tests/e2e/pages/skjema/vedlegg-steg.page.ts
@@ -66,6 +66,10 @@ export class VedleggStegPage {
     await expect(this.page.getByText(fileName)).toBeVisible();
   }
 
+  async deleteFileItem() {
+    await this.page.getByRole("button", { name: "Slett filen" }).click();
+  }
+
   async lagreOgFortsett() {
     await this.lagreOgFortsettButton.click();
   }

--- a/app/tests/e2e/specs/skjema/feilhandtering.spec.ts
+++ b/app/tests/e2e/specs/skjema/feilhandtering.spec.ts
@@ -111,6 +111,7 @@ test.describe("Feilhåndtering", () => {
               tilDato: "2026-12-31",
             },
           },
+          vedlegg: { harAnnenDokumentasjon: false },
         } as typeof testArbeidstakerSkjema.data,
       });
 

--- a/app/tests/e2e/specs/skjema/feilhandtering.spec.ts
+++ b/app/tests/e2e/specs/skjema/feilhandtering.spec.ts
@@ -43,8 +43,9 @@ test.describe("Feilhåndtering", () => {
       await familiemedlemmerStegPage.lagreOgFortsett();
 
       // Feilmelding skal nå være synlig
-      const alert = page.getByRole("alert").filter({ hasText: t.felles.feil });
-      await expect(alert).toBeVisible();
+      await expect(
+        page.getByRole("alert").filter({ hasText: t.felles.feil }),
+      ).toBeVisible();
 
       // Bruker skal fortsatt være på samme steg
       await familiemedlemmerStegPage.assertStillOnStep();
@@ -68,10 +69,11 @@ test.describe("Feilhåndtering", () => {
       await vedleggStegPage.assertIsVisible();
 
       // Feilmelding for henting av vedlegg skal vises
-      const alert = page
-        .getByRole("alert")
-        .filter({ hasText: t.vedleggSteg.feilVedHentingAvVedlegg });
-      await expect(alert).toBeVisible();
+      await expect(
+        page
+          .getByRole("alert")
+          .filter({ hasText: t.vedleggSteg.feilVedHentingAvVedlegg }),
+      ).toBeVisible();
     });
   });
 
@@ -121,8 +123,9 @@ test.describe("Feilhåndtering", () => {
       await sendKnapp.click();
 
       // Feilmelding skal vises
-      const alert = page.getByRole("alert").filter({ hasText: t.felles.feil });
-      await expect(alert).toBeVisible();
+      await expect(
+        page.getByRole("alert").filter({ hasText: t.felles.feil }),
+      ).toBeVisible();
 
       // Skal fortsatt være på oppsummeringssiden
       await expect(page).toHaveURL(
@@ -158,8 +161,9 @@ test.describe("Feilhåndtering", () => {
 
       // Feilmelding skal vises inne i modalen
       const modal = page.getByRole("dialog");
-      const alert = modal.getByRole("alert").filter({ hasText: t.felles.feil });
-      await expect(alert).toBeVisible();
+      await expect(
+        modal.getByRole("alert").filter({ hasText: t.felles.feil }),
+      ).toBeVisible();
     });
   });
 });

--- a/app/tests/e2e/specs/skjema/feilhandtering.spec.ts
+++ b/app/tests/e2e/specs/skjema/feilhandtering.spec.ts
@@ -36,7 +36,7 @@ test.describe("Feilhåndtering", () => {
       await familiemedlemmerStegPage.assertIsVisible();
 
       // Feilmelding skal ikke vises før submit
-      await expect(page.getByText(t.felles.feil)).toBeHidden();
+      await expect(page.getByText(t.felles.feilVedInnsending)).toBeHidden();
 
       // Fyll ut og submit
       await familiemedlemmerStegPage.harDuFamiliemedlemmerSomSkalVaereMedRadioGroup.NEI.click();
@@ -44,7 +44,7 @@ test.describe("Feilhåndtering", () => {
 
       // Feilmelding skal nå være synlig
       await expect(
-        page.getByRole("alert").filter({ hasText: t.felles.feil }),
+        page.getByRole("alert").filter({ hasText: t.felles.feilVedInnsending }),
       ).toBeVisible();
 
       // Bruker skal fortsatt være på samme steg
@@ -125,7 +125,7 @@ test.describe("Feilhåndtering", () => {
 
       // Feilmelding skal vises
       await expect(
-        page.getByRole("alert").filter({ hasText: t.felles.feil }),
+        page.getByRole("alert").filter({ hasText: t.felles.feilVedInnsending }),
       ).toBeVisible();
 
       // Skal fortsatt være på oppsummeringssiden

--- a/app/tests/e2e/specs/skjema/feilhandtering.spec.ts
+++ b/app/tests/e2e/specs/skjema/feilhandtering.spec.ts
@@ -1,0 +1,165 @@
+import { nb } from "~/i18n/nb";
+
+import {
+  mockFetchSkjema,
+  mockHentVedlegg,
+  mockHentVedleggFeil,
+  mockPostFamiliemedlemmerFeil,
+  mockSendInnSkjemaFeil,
+  mockSlettUtkastFeil,
+  setupApiMocksForArbeidstaker,
+} from "../../fixtures/api-mocks";
+import { expect, test } from "../../fixtures/test";
+import { testArbeidstakerSkjema, testUserInfo } from "../../fixtures/test-data";
+import { FamiliemedlemmerStegPage } from "../../pages/skjema/familiemedlemmer-steg.page";
+import { VedleggStegPage } from "../../pages/skjema/vedlegg-steg.page";
+
+const t = nb.translation;
+
+test.describe("Feilhåndtering", () => {
+  test.describe("SkjemaSteg - submit-feil viser Alert", () => {
+    test("viser feilmelding i steg når POST feiler", async ({ page }) => {
+      // Sett opp standard mocks, men overstyr familiemedlemmer med feil-mock
+      await setupApiMocksForArbeidstaker(
+        page,
+        testArbeidstakerSkjema,
+        testUserInfo,
+      );
+      await mockPostFamiliemedlemmerFeil(page, testArbeidstakerSkjema.id);
+
+      const familiemedlemmerStegPage = new FamiliemedlemmerStegPage(
+        page,
+        testArbeidstakerSkjema,
+      );
+
+      await familiemedlemmerStegPage.goto();
+      await familiemedlemmerStegPage.assertIsVisible();
+
+      // Feilmelding skal ikke vises før submit
+      await expect(page.getByText(t.felles.feil)).toBeHidden();
+
+      // Fyll ut og submit
+      await familiemedlemmerStegPage.harDuFamiliemedlemmerSomSkalVaereMedRadioGroup.NEI.click();
+      await familiemedlemmerStegPage.lagreOgFortsett();
+
+      // Feilmelding skal nå være synlig
+      const alert = page.getByRole("alert").filter({ hasText: t.felles.feil });
+      await expect(alert).toBeVisible();
+
+      // Bruker skal fortsatt være på samme steg
+      await familiemedlemmerStegPage.assertStillOnStep();
+    });
+  });
+
+  test.describe("VedleggSteg - hentVedlegg-feil", () => {
+    test("viser feilmelding når henting av vedlegg feiler", async ({
+      page,
+    }) => {
+      await setupApiMocksForArbeidstaker(
+        page,
+        testArbeidstakerSkjema,
+        testUserInfo,
+      );
+      await mockHentVedleggFeil(page, testArbeidstakerSkjema.id);
+
+      const vedleggStegPage = new VedleggStegPage(page, testArbeidstakerSkjema);
+
+      await vedleggStegPage.goto();
+      await vedleggStegPage.assertIsVisible();
+
+      // Feilmelding for henting av vedlegg skal vises
+      const alert = page
+        .getByRole("alert")
+        .filter({ hasText: t.vedleggSteg.feilVedHentingAvVedlegg });
+      await expect(alert).toBeVisible();
+    });
+  });
+
+  test.describe("SendInnSkjemaKnapp - innsending feiler", () => {
+    test("viser feilmelding når innsending feiler", async ({ page }) => {
+      await setupApiMocksForArbeidstaker(
+        page,
+        testArbeidstakerSkjema,
+        testUserInfo,
+      );
+      // Overstyr send-inn med feil
+      await mockSendInnSkjemaFeil(page, testArbeidstakerSkjema.id);
+      // Mock vedlegg for oppsummeringssiden
+      await mockHentVedlegg(page, testArbeidstakerSkjema.id);
+
+      // Naviger til oppsummeringssiden med utfylt data
+      await mockFetchSkjema(page, {
+        ...testArbeidstakerSkjema,
+        data: {
+          type: "UTSENDT_ARBEIDSTAKER_ARBEIDSTAKERS_DEL",
+          arbeidssituasjon: {
+            harVaertEllerSkalVaereILonnetArbeidFoerUtsending: true,
+            skalJobbeForFlereVirksomheter: false,
+          },
+          familiemedlemmer: { skalHaMedFamiliemedlemmer: false },
+          skatteforholdOgInntekt: {
+            erSkattepliktigTilNorgeIHeleutsendingsperioden: true,
+            mottarPengestotteFraAnnetEosLandEllerSveits: false,
+          },
+          tilleggsopplysninger: { harFlereOpplysningerTilSoknaden: false },
+          utsendingsperiodeOgLand: {
+            utsendelseLand: "SE",
+            utsendelsePeriode: {
+              fraDato: "2026-01-01",
+              tilDato: "2026-12-31",
+            },
+          },
+        } as typeof testArbeidstakerSkjema.data,
+      });
+
+      await page.goto(`/skjema/${testArbeidstakerSkjema.id}/oppsummering`);
+
+      // Klikk "Send søknad"
+      const sendKnapp = page.getByRole("button", {
+        name: t.felles.sendSoknad,
+      });
+      await sendKnapp.click();
+
+      // Feilmelding skal vises
+      const alert = page.getByRole("alert").filter({ hasText: t.felles.feil });
+      await expect(alert).toBeVisible();
+
+      // Skal fortsatt være på oppsummeringssiden
+      await expect(page).toHaveURL(
+        `/skjema/${testArbeidstakerSkjema.id}/oppsummering`,
+      );
+    });
+  });
+
+  test.describe("AvbrytOgSlettKnapp - sletting feiler", () => {
+    test("viser feilmelding i modal når sletting feiler", async ({ page }) => {
+      await setupApiMocksForArbeidstaker(
+        page,
+        testArbeidstakerSkjema,
+        testUserInfo,
+      );
+      await mockSlettUtkastFeil(page, testArbeidstakerSkjema.id);
+
+      const familiemedlemmerStegPage = new FamiliemedlemmerStegPage(
+        page,
+        testArbeidstakerSkjema,
+      );
+
+      await familiemedlemmerStegPage.goto();
+      await familiemedlemmerStegPage.assertIsVisible();
+
+      // Åpne avbryt-og-slett-modal
+      await page.getByRole("button", { name: t.felles.avbrytOgSlett }).click();
+
+      // Bekreft sletting
+      await page
+        .getByRole("button", { name: t.felles.jaAvbrytOgSlettUtkast })
+        .click();
+
+      // Feilmelding skal vises inne i modalen
+      const modal = page.getByRole("dialog");
+      const alert = modal.getByRole("alert").filter({ hasText: t.felles.feil });
+      await expect(alert).toBeVisible();
+    });
+  });
+});

--- a/app/tests/e2e/specs/skjema/feilhandtering.spec.ts
+++ b/app/tests/e2e/specs/skjema/feilhandtering.spec.ts
@@ -1,12 +1,15 @@
 import { nb } from "~/i18n/nb";
+import { VedleggFiltype } from "~/types/melosysSkjemaTypes";
 
 import {
   mockFetchSkjema,
   mockHentVedlegg,
   mockHentVedleggFeil,
+  mockLastOppVedlegg,
   mockPostFamiliemedlemmerFeil,
   mockSendInnSkjemaFeil,
   mockSlettUtkastFeil,
+  mockSlettVedleggFeil,
   setupApiMocksForArbeidstaker,
 } from "../../fixtures/api-mocks";
 import { expect, test } from "../../fixtures/test";
@@ -74,6 +77,55 @@ test.describe("Feilhåndtering", () => {
           .getByRole("alert")
           .filter({ hasText: t.vedleggSteg.feilVedHentingAvVedlegg }),
       ).toBeVisible();
+    });
+  });
+
+  test.describe("VedleggSteg - slettVedlegg-feil", () => {
+    test("vedlegg forblir synlig når sletting feiler", async ({ page }) => {
+      const skjemaId = testArbeidstakerSkjema.id;
+      const vedleggResponse = {
+        id: "vedlegg-456",
+        filnavn: "dokument.pdf",
+        filtype: VedleggFiltype.PDF,
+        filstorrelse: 5000,
+        opprettetDato: "2026-01-15T10:00:00Z",
+      };
+
+      await setupApiMocksForArbeidstaker(
+        page,
+        testArbeidstakerSkjema,
+        testUserInfo,
+      );
+      await mockHentVedlegg(page, skjemaId);
+      await mockLastOppVedlegg(page, skjemaId, vedleggResponse);
+      await mockSlettVedleggFeil(page, skjemaId);
+
+      const vedleggStegPage = new VedleggStegPage(page, testArbeidstakerSkjema);
+
+      await vedleggStegPage.goto();
+      await vedleggStegPage.assertIsVisible();
+      await vedleggStegPage.velgHarAnnenDokumentasjonJa();
+
+      // Last opp en fil
+      await vedleggStegPage.uploadFile(
+        "dokument.pdf",
+        "application/pdf",
+        Buffer.from("fake-pdf-content"),
+      );
+      await vedleggStegPage.assertFileItemVisible("dokument.pdf");
+
+      // Prøv å slette — skal feile
+      await vedleggStegPage.deleteFileItem();
+
+      // Feilmelding for sletting skal vises
+      await expect(
+        page
+          .getByRole("alert")
+          .filter({ hasText: t.vedleggSteg.feilVedSlettingAvVedlegg }),
+      ).toBeVisible();
+
+      // Vedlegget skal fortsatt være synlig (ikke fjernet fra UI)
+      await vedleggStegPage.assertFileItemVisible("dokument.pdf");
     });
   });
 


### PR DESCRIPTION
Erstatter react-hot-toast og stille `.catch(() => {})` med persistente Alert-komponenter fra Aksel. Feil vises inline i skjemaet i stedet for å forsvinne etter noen sekunder eller bli svelget.

Brukere fikk mangelfull eller for kortvarig tilbakemelding når API-kall feilet i skjemaet. Endringen gjør feilhåndteringen mer tilgjengelig og konkret, og bruker eksisterende innsendingsfeilmelding som informerer om å prøve igjen senere når innsending eller backend-validering feiler.
[MELOSYS-8086](https://jira.adeo.no/browse/MELOSYS-8086)

- Fjernet `react-hot-toast` fra alle skjemasteg, `main.tsx`, `validateSkjemaDefinisjon.ts` og `package.json`
- Erstattet stille feil med inline `Alert` i relevante skjema- og knappekomponenter
- Gjenbruker `felles.feilVedInnsending` ved submit-feil i `SkjemaSteg`, slik at bruker får beskjed om å prøve igjen senere
- Flyttet submit-feilmeldingen til under skjemainnholdet for bedre plassering i steget
- Vedlegg: viser feilmeldinger for både henting og sletting av vedlegg
- E2E-tester for feilhåndtering med API-mocks for 500-responser

## Testing
- [x] E2E-tester (`feilhandtering.spec.ts`)
- [x] Manuell testing lokalt

