### PR TITLE
8097 Fiks oppsummeringslenker med basepath

### DIFF
--- a/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
+++ b/app/src/pages/skjema/oppsummering/OppsummeringSteg.tsx
@@ -17,6 +17,7 @@ import type {
 } from "~/types/melosysSkjemaTypes.ts";
 
 import { SkjemaStegLoader } from "../components/SkjemaStegLoader.tsx";
+import { byggHrefMedBasePath, byggSkjemaStegHref } from "../skjemaHref.ts";
 import { finnManglendeSteg } from "../stegDataGetters.ts";
 import { STEG_REKKEFOLGE } from "../stegRekkefølge.ts";
 import { isArbeidsgiverOgArbeidstakersDel } from "../types.ts";
@@ -48,6 +49,7 @@ function OppsummeringStegContent({
 
   const erKombinertSkjema = isArbeidsgiverOgArbeidstakersDel(data);
   const harFeil = manglendeSteg.length > 0 || harInnsendingFeil;
+  const vedleggSteg = stegRekkefolge.find((s) => s.key === StegKey.VEDLEGG);
 
   useEffect(() => {
     if (harFeil) {
@@ -57,7 +59,14 @@ function OppsummeringStegContent({
   }, [harFeil]);
 
   const kanSendeInn = () => {
-    const manglendeSteg = finnManglendeSteg(skjema, stegRekkefolge, skjema.id);
+    const manglendeSteg = finnManglendeSteg(
+      skjema,
+      stegRekkefolge,
+      skjema.id,
+    ).map((steg) => ({
+      ...steg,
+      href: byggHrefMedBasePath(steg.href),
+    }));
 
     setManglendeSteg(manglendeSteg);
     setHarInnsendingFeil(false);
@@ -82,7 +91,7 @@ function OppsummeringStegContent({
       <ArbeidstakerOgArbeidsgiverOppsummering skjema={skjema} />
       {seksjoner.map(({ seksjonNavn, seksjon, data, stegKey }) => {
         const steg = stegRekkefolge.find((s) => s.key === stegKey);
-        const editHref = steg?.route.replace("$id", skjema.id) ?? "";
+        const editHref = steg ? byggSkjemaStegHref(steg.route, skjema.id) : "";
         return (
           <Fragment key={seksjonNavn}>
             {erKombinertSkjema && stegKey === StegKey.ARBEIDSSITUASJON && (
@@ -101,9 +110,7 @@ function OppsummeringStegContent({
       })}
       <VedleggOppsummering
         editHref={
-          stegRekkefolge
-            .find((s) => s.key === StegKey.VEDLEGG)
-            ?.route.replace("$id", skjema.id) ?? ""
+          vedleggSteg ? byggSkjemaStegHref(vedleggSteg.route, skjema.id) : ""
         }
         harAnnenDokumentasjon={skjema.data.vedlegg?.harAnnenDokumentasjon}
         skjemaId={skjema.id}

--- a/app/src/pages/skjema/skjemaHref.ts
+++ b/app/src/pages/skjema/skjemaHref.ts
@@ -2,7 +2,7 @@ export function byggHrefMedBasePath(
   href: string,
   basePath: string = import.meta.env.BASE_URL,
 ): string {
-  const normalisertBasePath = basePath.replace(/\/$/, "");
+  const normalisertBasePath = basePath.replace(/\/+$/, "");
   const normalisertHref = href.startsWith("/") ? href : `/${href}`;
 
   return `${normalisertBasePath}${normalisertHref}`;

--- a/app/src/pages/skjema/skjemaHref.ts
+++ b/app/src/pages/skjema/skjemaHref.ts
@@ -1,0 +1,17 @@
+export function byggHrefMedBasePath(
+  href: string,
+  basePath: string = import.meta.env.BASE_URL,
+): string {
+  const normalisertBasePath = basePath.replace(/\/$/, "");
+  const normalisertHref = href.startsWith("/") ? href : `/${href}`;
+
+  return `${normalisertBasePath}${normalisertHref}`;
+}
+
+export function byggSkjemaStegHref(
+  route: string,
+  skjemaId: string,
+  basePath: string = import.meta.env.BASE_URL,
+): string {
+  return byggHrefMedBasePath(route.replace("$id", skjemaId), basePath);
+}

--- a/app/tests/e2e/pages/skjema/oppsummering-steg.page.ts
+++ b/app/tests/e2e/pages/skjema/oppsummering-steg.page.ts
@@ -51,8 +51,11 @@ export class OppsummeringStegPage {
     });
   }
 
-  async goto() {
-    await this.page.goto(`/skjema/${this.skjema.id}/oppsummering`);
+  async goto(basePath = "") {
+    const normalisertBasePath = basePath.replace(/\/$/, "");
+    await this.page.goto(
+      `${normalisertBasePath}/skjema/${this.skjema.id}/oppsummering`,
+    );
   }
 
   async assertIsVisible() {
@@ -455,6 +458,16 @@ export class OppsummeringStegPage {
         "href",
         href,
       );
+    }
+  }
+
+  async assertEndreSvarLenkerHarHref(hrefs: string[]) {
+    for (const href of hrefs) {
+      await expect(
+        this.page
+          .locator(`a[href="${href}"]`)
+          .filter({ hasText: nb.translation.felles.endreSvar }),
+      ).toHaveCount(1);
     }
   }
 

--- a/app/tests/e2e/pages/skjema/oppsummering-steg.page.ts
+++ b/app/tests/e2e/pages/skjema/oppsummering-steg.page.ts
@@ -52,7 +52,7 @@ export class OppsummeringStegPage {
   }
 
   async goto(basePath = "") {
-    const normalisertBasePath = basePath.replace(/\/$/, "");
+    const normalisertBasePath = basePath.replace(/\/+$/, "");
     await this.page.goto(
       `${normalisertBasePath}/skjema/${this.skjema.id}/oppsummering`,
     );

--- a/app/tests/e2e/specs/skjema/oppsummering-basepath.spec.ts
+++ b/app/tests/e2e/specs/skjema/oppsummering-basepath.spec.ts
@@ -1,0 +1,97 @@
+import type { Page } from "@playwright/test";
+
+import type {
+  ArbeidsgiverensVirksomhetINorgeDto,
+  UtsendtArbeidstakerSkjemaDto,
+} from "~/types/melosysSkjemaTypes";
+
+import { test } from "../../fixtures/test";
+import {
+  testArbeidsgiverSkjema,
+  testOrganization,
+  testUserInfo,
+} from "../../fixtures/test-data";
+import { OppsummeringStegPage } from "../../pages/skjema/oppsummering-steg.page";
+
+const basePath = "/medlemskap-lovvalg/soknad";
+
+async function setupBasePathMocks(
+  page: Page,
+  skjema: UtsendtArbeidstakerSkjemaDto,
+) {
+  await page.route(`${basePath}/nav-dekoratoren-api/auth`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        authenticated: true,
+        ...testUserInfo,
+      }),
+    });
+  });
+
+  await page.route(`${basePath}/api/hentTilganger`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([testOrganization]),
+    });
+  });
+
+  await page.route(
+    `${basePath}/api/skjema/${skjema.id}/metadata`,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(skjema.metadata),
+      });
+    },
+  );
+
+  await page.route(
+    `${basePath}/api/skjema/utsendt-arbeidstaker/${skjema.id}`,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(skjema),
+      });
+    },
+  );
+}
+
+test.describe("Oppsummering med basepath", () => {
+  test.skip(
+    process.env.BASE_PATH !== `${basePath}/`,
+    `Kjøres med BASE_PATH=${basePath}/`,
+  );
+
+  test("prefikser Endre svar-lenker med basepath", async ({ page }) => {
+    const arbeidsgiverensVirksomhetINorgeData: ArbeidsgiverensVirksomhetINorgeDto =
+      {
+        erArbeidsgiverenOffentligVirksomhet: false,
+        erArbeidsgiverenBemanningsEllerVikarbyraa: false,
+        opprettholderArbeidsgiverenVanligDrift: true,
+      };
+    const skjema = {
+      ...testArbeidsgiverSkjema,
+      data: {
+        type: "UTSENDT_ARBEIDSTAKER_ARBEIDSGIVERS_DEL",
+        arbeidsgiverensVirksomhetINorge: arbeidsgiverensVirksomhetINorgeData,
+        vedlegg: { harAnnenDokumentasjon: false },
+      } as UtsendtArbeidstakerSkjemaDto["data"],
+    };
+
+    await setupBasePathMocks(page, skjema);
+
+    const oppsummeringStegPage = new OppsummeringStegPage(page, skjema);
+    await oppsummeringStegPage.goto(basePath);
+    await oppsummeringStegPage.assertIsVisible();
+
+    await oppsummeringStegPage.assertEndreSvarLenkerHarHref([
+      `${basePath}/skjema/${skjema.id}/arbeidsgiverens-virksomhet-i-norge`,
+      `${basePath}/skjema/${skjema.id}/vedlegg`,
+    ]);
+  });
+});


### PR DESCRIPTION
Fikser at `Endre svar`-lenker på oppsummeringssiden peker uten riktig ingress/basepath.

Oppsummeringssiden bruker plain `href`-lenker i Aksel `FormSummary.EditLink`, og disse ble tidligere bygget som `/skjema/...` uten `/medlemskap-lovvalg/soknad`. Det ga feil URL i dev/prod når søknaden kjøres bak ingress-basepath.
[MELOSYS-8097](https://jira.adeo.no/browse/MELOSYS-8097)

- Bygger oppsummeringens interne `href`-lenker med Vite `BASE_URL`
- Bruker samme basepath-håndtering for `Vedlegg` og feilsammendrag-lenker for manglende steg
- Legger til Playwright e2e-test som verifiserer `Endre svar`-lenker med prod-lignende `BASE_PATH`

## Testing

- [x] e2e tester