### PR TITLE
8056 Juster spacing i skjemaheader

### DIFF
--- a/app/src/components/SkjemaParterHeader.tsx
+++ b/app/src/components/SkjemaParterHeader.tsx
@@ -35,7 +35,7 @@ export function SkjemaParterHeader({ skjemaId }: { skjemaId: string }) {
     metadata.representasjonstype !== Representasjonstype.DEG_SELV;
 
   return (
-    <HStack gap="space-128" paddingBlock="space-16" wrap>
+    <HStack gap="space-24 space-128" paddingBlock="space-16" wrap>
       <Part
         tittel={t("skjemaParterHeader.arbeidsgiver")}
         navn={metadata.arbeidsgiverNavn}


### PR DESCRIPTION
Justerer spacing i skjemaheaderen som viser valgt arbeidsgiver og arbeidstaker.

Headeren bruker fortsatt responsiv wrap: partene ligger ved siden av hverandre når skjermen er bred nok, og brytes over to linjer på smal skjerm. Denne endringen gjør at rad-gapet ved slik wrapping er mindre, mens den store horisontale avstanden beholdes.
[MELOSYS-8056](https://jira.adeo.no/browse/MELOSYS-8056)

- Beholder arbeidsgiver og arbeidstaker horisontalt når det er plass
- Reduserer vertikal spacing når headeren brytes over to linjer

## Testing
- [x] `manuell testing`