### PR TITLE
8102 Legg til informasjonstekst om ettersendelse

### DIFF
--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -435,6 +435,11 @@ export const en = {
       herKanDu: "Here you can:",
       infoBullet1: "fill out an application.",
       infoBullet2: "view started and previously submitted applications.",
+      ettersendelse:
+        "You cannot submit additional documentation here. You can either send a new application with attachments or send the documentation via ",
+      ettersendelseLenke: "Send documents to Nav",
+      ettersendelseLenkeUrl:
+        "https://www.nav.no/fyllut-ettersending/nav020807/innsendingsvalg",
     },
     oversiktArbeidsgiver: {
       tittel: "Overview page for applications",
@@ -443,6 +448,8 @@ export const en = {
         "fill out an application for your employer and their employees.",
       infoBullet2: "view accesses and mandates you have been granted.",
       infoBullet3: "view started and previously submitted applications.",
+      ettersendelse:
+        "You cannot submit additional documentation here. Additional documents can be sent as attachments in a new application.",
     },
     oversiktRadgiver: {
       tittel: "Overview page for applications",
@@ -451,6 +458,8 @@ export const en = {
         "fill out an application for an employer and their employees.",
       infoBullet2: "view accesses and mandates you have been granted.",
       infoBullet3: "view started and previously submitted applications.",
+      ettersendelse:
+        "You cannot submit additional documentation here. Additional documents can be sent as attachments in a new application.",
     },
     oversiktAnnenPerson: {
       tittel: "Overview page for applications",
@@ -458,6 +467,8 @@ export const en = {
       infoBullet1:
         "fill out an application for people who have granted you a mandate.",
       infoBullet2: "view started and previously submitted applications.",
+      ettersendelse:
+        "You cannot submit additional documentation here. Additional documents can be sent as attachments in a new application.",
       personVelgerLabel:
         "Select the person you want to fill out an application for",
       personVelgerBeskrivelse:

--- a/app/src/i18n/nb.ts
+++ b/app/src/i18n/nb.ts
@@ -325,6 +325,11 @@ export const nb = {
       herKanDu: "Her kan du:",
       infoBullet1: "fylle ut søknad.",
       infoBullet2: "se påbegynte og tidligere innsendte søknader.",
+      ettersendelse:
+        "Du kan ikke ettersende dokumentasjon her. Du kan enten sende en ny søknad med vedlegg eller sende dokumentasjonen via ",
+      ettersendelseLenke: "Send dokumenter til Nav",
+      ettersendelseLenkeUrl:
+        "https://www.nav.no/fyllut-ettersending/nav020807/innsendingsvalg",
     },
     oversiktArbeidsgiver: {
       tittel: "Oversiktsside for søknader",
@@ -333,6 +338,8 @@ export const nb = {
         "fylle ut søknad for din arbeidsgiver og dennes arbeidstakere.",
       infoBullet2: "se tilganger og fullmakter som du har fått.",
       infoBullet3: "se påbegynte og tidligere innsendte søknader.",
+      ettersendelse:
+        "Du kan ikke ettersende dokumentasjon her. Ettersendte dokumenter kan sendes i en ny søknad som vedlegg.",
     },
     oversiktRadgiver: {
       tittel: "Oversiktsside for søknader",
@@ -341,12 +348,16 @@ export const nb = {
         "fylle ut søknad for en arbeidsgiver og dennes arbeidstakere.",
       infoBullet2: "se tilganger og fullmakter som du har fått.",
       infoBullet3: "se påbegynte og tidligere innsendte søknader.",
+      ettersendelse:
+        "Du kan ikke ettersende dokumentasjon her. Ettersendte dokumenter kan sendes i en ny søknad som vedlegg.",
     },
     oversiktAnnenPerson: {
       tittel: "Oversiktsside for søknader",
       herKanDu: "Her kan du:",
       infoBullet1: "fylle ut søknad for personer som har gitt deg fullmakt.",
       infoBullet2: "se påbegynte og tidligere innsendte søknader.",
+      ettersendelse:
+        "Du kan ikke ettersende dokumentasjon her. Ettersendte dokumenter kan sendes i en ny søknad som vedlegg.",
       personVelgerLabel: "Velg person du skal fylle ut søknad for",
       personVelgerBeskrivelse:
         "Listen inneholder alle personer du har fått fullmakt fra på nav.no.",

--- a/app/src/pages/oversikt/OversiktPage.tsx
+++ b/app/src/pages/oversikt/OversiktPage.tsx
@@ -121,7 +121,10 @@ export function OversiktPage({ representasjonskontekst }: OversiktPageProps) {
         return (
           <>
             {t("oversiktDegSelv.ettersendelse")}
-            <Link href={t("oversiktDegSelv.ettersendelseLenkeUrl")}>
+            <Link
+              href={t("oversiktDegSelv.ettersendelseLenkeUrl")}
+              target="_blank"
+            >
               {t("oversiktDegSelv.ettersendelseLenke")}
             </Link>
           </>

--- a/app/src/pages/oversikt/OversiktPage.tsx
+++ b/app/src/pages/oversikt/OversiktPage.tsx
@@ -3,6 +3,7 @@ import {
   BodyShort,
   GuidePanel,
   Heading,
+  Link,
   Loader,
   VStack,
 } from "@navikt/ds-react";
@@ -114,6 +115,30 @@ export function OversiktPage({ representasjonskontekst }: OversiktPageProps) {
     }
   };
 
+  const getEttersendelseTekst = () => {
+    switch (representasjonskontekst.representasjonstype) {
+      case Representasjonstype.DEG_SELV: {
+        return (
+          <>
+            {t("oversiktDegSelv.ettersendelse")}
+            <Link href={t("oversiktDegSelv.ettersendelseLenkeUrl")}>
+              {t("oversiktDegSelv.ettersendelseLenke")}
+            </Link>
+          </>
+        );
+      }
+      case Representasjonstype.ARBEIDSGIVER: {
+        return t("oversiktArbeidsgiver.ettersendelse");
+      }
+      case Representasjonstype.RADGIVER: {
+        return t("oversiktRadgiver.ettersendelse");
+      }
+      case Representasjonstype.ANNEN_PERSON: {
+        return t("oversiktAnnenPerson.ettersendelse");
+      }
+    }
+  };
+
   return (
     <VStack gap="space-24">
       <GuidePanel
@@ -133,6 +158,9 @@ export function OversiktPage({ representasjonskontekst }: OversiktPageProps) {
             </li>
           ))}
         </ul>
+        <BodyShort size="small" className="mt-4">
+          {getEttersendelseTekst()}
+        </BodyShort>
       </GuidePanel>
       <UtkastListe representasjonskontekst={representasjonskontekst} />
       <SoknadStarter representasjonskontekst={representasjonskontekst} />

--- a/app/src/pages/oversikt/OversiktPage.tsx
+++ b/app/src/pages/oversikt/OversiktPage.tsx
@@ -124,6 +124,7 @@ export function OversiktPage({ representasjonskontekst }: OversiktPageProps) {
             <Link
               href={t("oversiktDegSelv.ettersendelseLenkeUrl")}
               target="_blank"
+              rel="noopener noreferrer"
             >
               {t("oversiktDegSelv.ettersendelseLenke")}
             </Link>

--- a/app/tests/e2e/pages/oversikt/oversikt.page.ts
+++ b/app/tests/e2e/pages/oversikt/oversikt.page.ts
@@ -270,15 +270,13 @@ export class OversiktPage {
         await expect(this.radgiverInfo).not.toBeVisible();
         break;
       }
-      case Representasjonstype.ARBEIDSGIVER:
-      case Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT: {
+      case Representasjonstype.ARBEIDSGIVER: {
         await expect(this.arbeidsgiverInfo).toBeVisible();
         await expect(this.annenPersonInfo).not.toBeVisible();
         await expect(this.radgiverInfo).not.toBeVisible();
         break;
       }
-      case Representasjonstype.RADGIVER:
-      case Representasjonstype.RADGIVER_MED_FULLMAKT: {
+      case Representasjonstype.RADGIVER: {
         await expect(this.radgiverInfo).toBeVisible();
         await expect(this.annenPersonInfo).not.toBeVisible();
         await expect(this.arbeidsgiverInfo).not.toBeVisible();
@@ -303,15 +301,13 @@ export class OversiktPage {
         );
         break;
       }
-      case Representasjonstype.ARBEIDSGIVER:
-      case Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT: {
+      case Representasjonstype.ARBEIDSGIVER: {
         await expect(
           this.page.getByText(ettersendelseTekster.arbeidsgiver),
         ).toBeVisible();
         break;
       }
-      case Representasjonstype.RADGIVER:
-      case Representasjonstype.RADGIVER_MED_FULLMAKT: {
+      case Representasjonstype.RADGIVER: {
         await expect(
           this.page.getByText(ettersendelseTekster.radgiver),
         ).toBeVisible();

--- a/app/tests/e2e/pages/oversikt/oversikt.page.ts
+++ b/app/tests/e2e/pages/oversikt/oversikt.page.ts
@@ -24,6 +24,15 @@ const bekreftelseTekster = {
   radgiverInfo: translations.oversiktBekreftelse.radgiverInfo,
 };
 
+const ettersendelseTekster = {
+  degSelv: translations.oversiktDegSelv.ettersendelse,
+  degSelvLenke: translations.oversiktDegSelv.ettersendelseLenke,
+  degSelvLenkeUrl: translations.oversiktDegSelv.ettersendelseLenkeUrl,
+  arbeidsgiver: translations.oversiktArbeidsgiver.ettersendelse,
+  radgiver: translations.oversiktRadgiver.ettersendelse,
+  annenPerson: translations.oversiktAnnenPerson.ettersendelse,
+};
+
 export class OversiktPage {
   readonly page: Page;
   readonly representasjonstype: Representasjonstype;
@@ -273,6 +282,45 @@ export class OversiktPage {
         await expect(this.radgiverInfo).toBeVisible();
         await expect(this.annenPersonInfo).not.toBeVisible();
         await expect(this.arbeidsgiverInfo).not.toBeVisible();
+        break;
+      }
+    }
+  }
+
+  async assertEttersendelseTekstForRepresentasjonstype() {
+    switch (this.representasjonstype) {
+      case Representasjonstype.DEG_SELV: {
+        await expect(
+          this.page.getByText(ettersendelseTekster.degSelv),
+        ).toBeVisible();
+        const lenke = this.page.getByRole("link", {
+          name: ettersendelseTekster.degSelvLenke,
+        });
+        await expect(lenke).toBeVisible();
+        await expect(lenke).toHaveAttribute(
+          "href",
+          ettersendelseTekster.degSelvLenkeUrl,
+        );
+        break;
+      }
+      case Representasjonstype.ARBEIDSGIVER:
+      case Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT: {
+        await expect(
+          this.page.getByText(ettersendelseTekster.arbeidsgiver),
+        ).toBeVisible();
+        break;
+      }
+      case Representasjonstype.RADGIVER:
+      case Representasjonstype.RADGIVER_MED_FULLMAKT: {
+        await expect(
+          this.page.getByText(ettersendelseTekster.radgiver),
+        ).toBeVisible();
+        break;
+      }
+      case Representasjonstype.ANNEN_PERSON: {
+        await expect(
+          this.page.getByText(ettersendelseTekster.annenPerson),
+        ).toBeVisible();
         break;
       }
     }

--- a/app/tests/e2e/specs/oversikt.spec.ts
+++ b/app/tests/e2e/specs/oversikt.spec.ts
@@ -105,6 +105,86 @@ test.describe("Oversikt", () => {
   });
 });
 
+test.describe("Oversikt — Ettersendelse-tekst i GuidePanel", () => {
+  test("DEG_SELV: viser ettersendelsestekst med lenke til nav.no", async ({
+    page,
+  }) => {
+    await setupApiMocksForOversikt(
+      page,
+      testUserInfo,
+      [],
+      emptyUtkastListe,
+      emptyInnsendteSoknader,
+    );
+
+    const oversiktPage = new OversiktPage(page, Representasjonstype.DEG_SELV);
+    await oversiktPage.goto();
+    await oversiktPage.assertIsVisible();
+    await oversiktPage.assertEttersendelseTekstForRepresentasjonstype();
+  });
+
+  test("ARBEIDSGIVER: viser ettersendelsestekst uten lenke", async ({
+    page,
+  }) => {
+    await setupApiMocksForOversikt(
+      page,
+      testUserInfo,
+      [testOrganization],
+      emptyUtkastListe,
+      emptyInnsendteSoknader,
+    );
+    await mockHentTilganger(page, [testOrganization]);
+
+    const oversiktPage = new OversiktPage(
+      page,
+      Representasjonstype.ARBEIDSGIVER,
+    );
+    await oversiktPage.goto();
+    await oversiktPage.assertIsVisible();
+    await oversiktPage.assertEttersendelseTekstForRepresentasjonstype();
+  });
+
+  test("RÅDGIVER: viser ettersendelsestekst uten lenke", async ({ page }) => {
+    await setupApiMocksForOversikt(
+      page,
+      testUserInfo,
+      [testArbeidsgiverOrganization],
+      emptyUtkastListe,
+      emptyInnsendteSoknader,
+    );
+    await mockHentTilganger(page, [testArbeidsgiverOrganization]);
+    await mockGetEregOrganisasjonMedJuridiskEnhet(
+      page,
+      testRadgiverfirmaOrganisasjon,
+    );
+
+    const oversiktPage = new OversiktPage(page, Representasjonstype.RADGIVER);
+    await oversiktPage.gotoWithRadgiver(testRadgiverfirmaOrgnr);
+    await oversiktPage.assertIsVisible();
+    await oversiktPage.assertEttersendelseTekstForRepresentasjonstype();
+  });
+
+  test("ANNEN_PERSON: viser ettersendelsestekst uten lenke", async ({
+    page,
+  }) => {
+    await setupApiMocksForOversikt(
+      page,
+      testUserInfo,
+      [],
+      emptyUtkastListe,
+      emptyInnsendteSoknader,
+    );
+
+    const oversiktPage = new OversiktPage(
+      page,
+      Representasjonstype.ANNEN_PERSON,
+    );
+    await oversiktPage.goto();
+    await oversiktPage.assertIsVisible();
+    await oversiktPage.assertEttersendelseTekstForRepresentasjonstype();
+  });
+});
+
 test.describe("Oversikt — Start søknad POST-payload", () => {
   test("DEG_SELV: sender korrekt payload med arbeidstaker fra innlogget bruker", async ({
     page,


### PR DESCRIPTION
Legger til informasjonstekst om ettersendelse av dokumentasjon i GuidePanel på oversiktssiden.
Brukere må informeres om at de ikke kan ettersende dokumentasjon via søknadssiden.
Teksten varierer basert på representasjonstype: privatpersoner får en lenke til
"Send dokumenter til Nav", mens arbeidsgiver/rådgiver/fullmektig får info om at
ettersendte dokumenter kan sendes i en ny søknad som vedlegg.
[MELOSYS-8102](https://jira.adeo.no/browse/MELOSYS-8102)
- Ny ettersendelsestekst i GuidePanel på oversiktssiden for alle representasjonstyper
- DEG_SELV: tekst med lenke til nav.no ettersending
- ARBEIDSGIVER/RÅDGIVER/ANNEN_PERSON: ren tekst i nb.ts og en.ts
- E2e-tester for ettersendelsestekst per representasjonstype
## Testing
- [x] Playwright e2e-tester
- [x] Manuell testing lokalt
