### PR TITLE
8108 Legg til automatisk deploy av dev-brancher til dev-gcp

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'dev/**'
     paths:
       - '.github/workflows/deploy.yaml'
       - 'app/**'
@@ -90,7 +91,6 @@ jobs:
           RESOURCE: .nais/nais-dev.yaml
           WORKLOAD_IMAGE: ${{needs.build.outputs.image}}
 
-  # TODO: Skal skilles ut i releases, men det gjøres i MELOSYS-7933. I førsteomgang deployer vi automatisk til prod ved merge.
   deploy-prod:
     name: Deploy prod-gcp
     if: github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -221,6 +221,15 @@ flowchart LR
 
 Se `useSkjemaDefinisjon.ts` og `skjemaDefinisjonA1.ts` for detaljer.
 
+## Deploy
+
+Appen deployes automatisk via GitHub Actions til NAIS-plattformen:
+
+- **Dev-miljø**: Automatisk deploy ved push til `main`-branch eller `dev/**`-brancher
+- **Prod-miljø**: Automatisk deploy kun ved push til `main`-branch
+
+For å teste endringer i dev uten å deploye til prod, opprett en branch med prefix `dev/` (f.eks. `dev/min-feature`) og push til GitHub.
+
 ## Kodestandarder
 
 - ESLint med strenge regler (Unicorn, React, import-sorting)


### PR DESCRIPTION
Legger til støtte for automatisk deploy av dev-brancher til dev-gcp.

Per i dag deployer workflows kun fra main, og da til både dev og prod. Det gjør det
umulig å teste endringer i dev uten å også trigge prod-deploy. Med denne endringen
kan utviklere pushe til `dev/`-prefixede brancher for å deploye kun til dev-gcp.
[MELOSYS-8108](https://jira.adeo.no/browse/MELOSYS-8108)

- `dev/**`-brancher trigger build + deploy til dev-gcp
- `main` deployer fortsatt til både dev-gcp og prod-gcp
- Prod-deploy har fortsatt eksplisitt guard (`if: github.ref == 'refs/heads/main'`)
- Fjernet utdatert TODO-kommentar (MELOSYS-7933)
- Oppdatert README med deploy-dokumentasjon

Venter med å slette https://jira.adeo.no/browse/MELOSYS-7933 til Isa er tilbake, disse endringene her er bare mvp løsning for å gjøre det mulig å deploye til bare dev
