### PR TITLE
8107 Erstatt Alert med InfoCard i familiemedlemmer-steget

### DIFF
--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -173,14 +173,12 @@ export const en = {
       tittel: "Family Members",
       duMaSvarePaOmDuHarFamiliemedlemmerSomSkalVaereMed:
         "You must answer whether you have a spouse, partner, cohabitant or children who will accompany you",
+      infokortTittel: "Accompanying family members",
       informasjonOmEgenSoknad:
-        "If family members need clarification of their social security affiliation, they must submit their own application. Accompanying family members can apply using the form:",
+        "For accompanying children under 18 years of age that you are applying on behalf of, and for other family members who need clarification of their social security affiliation, the following form must be used:",
       soknadsskjemaLenke: "https://www.nav.no/fyllut/nav020807?lang=en",
       soknadsskjemaNavn:
-        "application for determination of applicable social security legislation during a stay in the EEA or Switzerland",
-      somLiggerPaNavNo: " available at nav.no.",
-      sendeSoknadForBarn:
-        "You can submit an application for children under 18 using this form.",
+        "Application for determination of applicable social security legislation during a stay in the EEA or Switzerland",
     },
     tilleggsopplysningerSteg: {
       tittel: "Additional Information",

--- a/app/src/i18n/nb.ts
+++ b/app/src/i18n/nb.ts
@@ -149,14 +149,12 @@ export const nb = {
       tittel: "Familiemedlemmer",
       duMaSvarePaOmDuHarFamiliemedlemmerSomSkalVaereMed:
         "Du må svare på om du har ektefelle, partner, samboer eller barn som skal være med deg",
+      infokortTittel: "Medfølgende familiemedlemmer",
       informasjonOmEgenSoknad:
-        "Hvis familiemedlemmer trenger avklaring av sin trygdetilhørighet, må de sende inn egen søknad. Medfølgende familiemedlemmer kan søke i skjemaet:",
+        "For medfølgende barn under 18 år som du søker på vegne av og for andre familiemedlemmer som trenger avklaring om sin trygdetilhørighet, skal følgende skjema benyttes:",
       soknadsskjemaLenke: "https://www.nav.no/fyllut/nav020807",
       soknadsskjemaNavn:
-        "søknad om avklaring av trygdetilhørighet under opphold i EØS eller Sveits",
-      somLiggerPaNavNo: " som ligger på nav.no.",
-      sendeSoknadForBarn:
-        "Du kan sende søknad for barn under 18 år på nevnte skjema.",
+        "Søknad om avklaring av trygdetilhørighet under opphold i EØS eller Sveits",
     },
     tilleggsopplysningerSteg: {
       tittel: "Tilleggsopplysninger",

--- a/app/src/pages/skjema/familiemedlemmer/FamiliemedlemmerSteg.tsx
+++ b/app/src/pages/skjema/familiemedlemmer/FamiliemedlemmerSteg.tsx
@@ -99,12 +99,12 @@ function FamiliemedlemmerStegContent({
           {skalHaMedFamiliemedlemmer && (
             <InfoCard className="mt-6" data-color="info">
               <InfoCard.Header icon={<InformationSquareIcon aria-hidden />}>
-                <InfoCard.Title as="h3">
+                <InfoCard.Title as="h2">
                   {t("familiemedlemmerSteg.infokortTittel")}
                 </InfoCard.Title>
               </InfoCard.Header>
               <InfoCard.Content>
-                <div className="flex flex-col gap-6 pb-8">
+                <div className="flex flex-col gap-6">
                   <BodyLong>
                     {t("familiemedlemmerSteg.informasjonOmEgenSoknad")}
                   </BodyLong>

--- a/app/src/pages/skjema/familiemedlemmer/FamiliemedlemmerSteg.tsx
+++ b/app/src/pages/skjema/familiemedlemmer/FamiliemedlemmerSteg.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Alert, BodyLong, Link } from "@navikt/ds-react";
+import { InformationSquareIcon } from "@navikt/aksel-icons";
+import { BodyLong, InfoCard, Link } from "@navikt/ds-react";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
@@ -96,22 +97,27 @@ function FamiliemedlemmerStegContent({
           />
 
           {skalHaMedFamiliemedlemmer && (
-            <Alert className="mt-4" variant="info">
-              <BodyLong>
-                {t("familiemedlemmerSteg.informasjonOmEgenSoknad")}{" "}
-                <Link
-                  href={t("familiemedlemmerSteg.soknadsskjemaLenke")}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {t("familiemedlemmerSteg.soknadsskjemaNavn")}
-                </Link>
-                {t("familiemedlemmerSteg.somLiggerPaNavNo")}
-              </BodyLong>
-              <BodyLong className="mt-2">
-                {t("familiemedlemmerSteg.sendeSoknadForBarn")}
-              </BodyLong>
-            </Alert>
+            <InfoCard className="mt-6" data-color="info">
+              <InfoCard.Header icon={<InformationSquareIcon aria-hidden />}>
+                <InfoCard.Title as="h3">
+                  {t("familiemedlemmerSteg.infokortTittel")}
+                </InfoCard.Title>
+              </InfoCard.Header>
+              <InfoCard.Content>
+                <div className="flex flex-col gap-6 pb-8">
+                  <BodyLong>
+                    {t("familiemedlemmerSteg.informasjonOmEgenSoknad")}
+                  </BodyLong>
+                  <Link
+                    href={t("familiemedlemmerSteg.soknadsskjemaLenke")}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {t("familiemedlemmerSteg.soknadsskjemaNavn")}
+                  </Link>
+                </div>
+              </InfoCard.Content>
+            </InfoCard>
           )}
         </SkjemaSteg>
       </form>


### PR DESCRIPTION
Erstatter Alert-komponent med Aksel InfoCard i familiemedlemmer-steget for bedre visuell struktur.

Infomeldingen om medfølgende familiemedlemmer skal vises som et InfoCard med egen header
og tydeligere separasjon mellom brødtekst og lenke, i tråd med oppdatert design.
[MELOSYS-8107](https://jira.adeo.no/browse/MELOSYS-8107)

- Erstatter `Alert` med `InfoCard` (Aksel) med header, ikon og content-struktur
- Ny header-tekst: «Medfølgende familiemedlemmer»
- Oppdatert brødtekst og lenke med linjeskift/luft mellom
- Oppdatert i18n-nøkler (nb og en) — fjernet ubrukte nøkler

## Testing
- [x] Manuell testing lokalt
