### PR TITLE
NOJIRA Fjern paths-filter fra deploy-workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,11 +5,6 @@ on:
     branches:
       - 'main'
       - 'dev/**'
-    paths:
-      - '.github/workflows/deploy.yaml'
-      - 'app/**'
-      - 'server/**'
-      - '.nais/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Fjerner paths-filteret fra deploy-workflowen. Filteret begrenset workflow-triggere til kun endringer i app/, server/, .nais/ og workflow-filen selv. Dette skapte problemer med dev-branch-deploy — brancher med endringer i disse mappene trigget ikke workflow ved push fordi GitHub Actions paths-filter ser på diffen i selve pushen, ikke total diff mot main.

melosys-skjema-api har ikke et tilsvarende paths-filter, så dette gjør oppsettet konsistent.

- Fjernet paths-filter fra on.push-triggeren
