### PR TITLE
Fikser accessible name på arbeidstaker-comboboxen

### DIFF
--- a/app/src/pages/oversikt/components/ArbeidstakerVelger.tsx
+++ b/app/src/pages/oversikt/components/ArbeidstakerVelger.tsx
@@ -237,7 +237,7 @@ export function ArbeidstakerVelger({
             <div className="navds-form-field navds-form-field--medium">
               {personerMedFullmakt.length > 0 && (
                 <>
-                  <Label className="navds-form-field__label">
+                  <Label as="span" className="navds-form-field__label">
                     {erAnnenPerson
                       ? t("oversiktAnnenPerson.personVelgerLabel")
                       : t("oversiktFelles.arbeidstakerMedFullmaktLabel")}
@@ -289,17 +289,19 @@ export function ArbeidstakerVelger({
                     </Link>
                   </InlineMessage>
                 ) : (
-                  // Vi bruker tom label="" fordi vi viser egen Label og BodyShort over
-                  // for å sikre at label og beskrivelse er synlig både når Combobox
-                  // vises og når valgt person vises i boks. Combobox har ikke innebygd clear-knapp.
                   <UNSAFE_Combobox
                     error={
                       error
                         ? "Kunne ikke laste personer med fullmakt"
                         : undefined
                     }
+                    hideLabel
                     isLoading={isLoading}
-                    label=""
+                    label={
+                      erAnnenPerson
+                        ? t("oversiktAnnenPerson.personVelgerLabel")
+                        : t("oversiktFelles.arbeidstakerMedFullmaktLabel")
+                    }
                     onToggleSelected={handleComboboxChange}
                     options={comboboxOptions}
                     placeholder={t(

--- a/app/src/pages/oversikt/components/ArbeidstakerVelger.tsx
+++ b/app/src/pages/oversikt/components/ArbeidstakerVelger.tsx
@@ -289,6 +289,11 @@ export function ArbeidstakerVelger({
                     </Link>
                   </InlineMessage>
                 ) : (
+                  // UNSAFE_Combobox har ingen clear-knapp, så når en person er valgt
+                  // bytter vi den ut med en egen boks med kryss. Derfor ligger label og
+                  // beskrivelse utenfor den, så de blir stående i begge tilstander.
+                  // hideLabel skjuler komponentens egen label så vi slipper den dobbelt –
+                  // den beholdes for skjermlesere.
                   <UNSAFE_Combobox
                     error={
                       error

--- a/app/tests/e2e/pages/oversikt/oversikt.page.ts
+++ b/app/tests/e2e/pages/oversikt/oversikt.page.ts
@@ -194,11 +194,9 @@ export class OversiktPage {
 
   /** Med fullmakt: Select person from the fullmakt combobox */
   async selectArbeidstakerMedFullmakt(personName: string) {
-    // The UNSAFE_Combobox has label="" with a separate Label rendered above it,
-    // so we locate by placeholder text instead
-    const fullmaktCombobox = this.page.getByPlaceholder(
-      translations.oversiktFelles.arbeidstakerMedFullmaktPlaceholder,
-    );
+    const fullmaktCombobox = this.page.getByRole("combobox", {
+      name: translations.oversiktFelles.arbeidstakerMedFullmaktLabel,
+    });
     await fullmaktCombobox.click();
     await this.page
       .getByRole("option", { name: new RegExp(personName) })

--- a/app/tests/e2e/specs/oversikt.spec.ts
+++ b/app/tests/e2e/specs/oversikt.spec.ts
@@ -1,3 +1,4 @@
+import { nb } from "~/i18n/nb";
 import { Representasjonstype } from "~/types/melosysSkjemaTypes";
 
 import {
@@ -321,7 +322,7 @@ test.describe("Oversikt — Start søknad POST-payload", () => {
     await oversiktPage.selectSkalFylleUtJa();
     await expect(
       page.getByRole("combobox", {
-        name: /Velg arbeidstaker du skal fylle ut søknad for/,
+        name: nb.translation.oversiktFelles.arbeidstakerMedFullmaktLabel,
       }),
     ).toBeVisible();
 

--- a/app/tests/e2e/specs/oversikt.spec.ts
+++ b/app/tests/e2e/specs/oversikt.spec.ts
@@ -319,6 +319,11 @@ test.describe("Oversikt — Start søknad POST-payload", () => {
 
     // Select "Ja" for fullmakt radio
     await oversiktPage.selectSkalFylleUtJa();
+    await expect(
+      page.getByRole("combobox", {
+        name: /Velg arbeidstaker du skal fylle ut søknad for/,
+      }),
+    ).toBeVisible();
 
     // Select person from fullmakt combobox
     await oversiktPage.selectArbeidstakerMedFullmakt(


### PR DESCRIPTION
Fikser at comboboxen for valg av arbeidstaker får et korrekt assosiert accessible name uten å endre synlig UI.

Dette fjerner den tomme/uassosierte labelen som UU-verktøyet flagger på oversiktssiden for fullmakt, samtidig som den synlige overskriften og beskrivelsen forblir uendret.
[MELOSYS-8090](https://jira.adeo.no/browse/MELOSYS-8090)

- Gjør den synlige overskriften til `span` slik at den ikke lenger blir en ekstra `<label>`
- Gir `UNSAFE_Combobox` ekte labeltekst og skjuler den visuelt
- Oppdaterer e2e-page object til å bruke accessible name
- Legger til e2e-assertion for comboboxens accessible name

## Testing
- [x] `manuell testing`
- [x] `e2e`
