### PR TITLE
7383 Legg til hover-effekt på representasjonsvalg

### DIFF
--- a/app/src/components/RepresentasjonVelger.tsx
+++ b/app/src/components/RepresentasjonVelger.tsx
@@ -41,7 +41,11 @@ function RepresentationCard({ option, onSelect }: RepresentationCardProps) {
     >
       <HStack align="center" gap="space-16" justify="space-between">
         <HStack align="center" gap="space-16">
-          <Icon aria-hidden className="text-ax-text-accent" fontSize="1.75rem" />
+          <Icon
+            aria-hidden
+            className="text-ax-text-accent"
+            fontSize="1.75rem"
+          />
           <div>
             <BodyShort weight="semibold">{t(option.labelKey)}</BodyShort>
             {option.descriptionKey && (

--- a/app/src/components/RepresentasjonVelger.tsx
+++ b/app/src/components/RepresentasjonVelger.tsx
@@ -35,13 +35,13 @@ function RepresentationCard({ option, onSelect }: RepresentationCardProps) {
 
   return (
     <button
-      className="w-full text-left border border-border-subtle rounded px-4 py-4 hover:bg-surface-action-subtle transition-colors cursor-pointer"
+      className="w-full text-left border border-ax-border-neutral-subtle rounded px-4 py-4 cursor-pointer transition-colors hover:bg-ax-bg-accent-soft hover:border-ax-border-accent"
       onClick={() => onSelect(option.type)}
       type="button"
     >
       <HStack align="center" gap="space-16" justify="space-between">
         <HStack align="center" gap="space-16">
-          <Icon aria-hidden className="text-icon-action" fontSize="1.75rem" />
+          <Icon aria-hidden className="text-ax-text-accent" fontSize="1.75rem" />
           <div>
             <BodyShort weight="semibold">{t(option.labelKey)}</BodyShort>
             {option.descriptionKey && (
@@ -51,7 +51,7 @@ function RepresentationCard({ option, onSelect }: RepresentationCardProps) {
         </HStack>
         <ChevronRightIcon
           aria-hidden
-          className="text-icon-action"
+          className="text-ax-text-accent"
           fontSize="1.5rem"
         />
       </HStack>


### PR DESCRIPTION
Legger til tydelig hover-effekt på valgene i representasjonsvelgeren.

Endringen gjør representasjonsvalgene mer synlige ved hover og gir bedre visuell tilbakemelding til brukeren.
[MELOSYS-7383](https://jira.adeo.no/browse/MELOSYS-7383)

- Oppdatert hover-state for representasjonskort
- Bruker Aksel accent-farger på ikoner og hover-kantlinje

## Testing
- [ ] Enhetstester
- [ ] Manuell testing lokalt