### PR TITLE
Bygg image for arm64 og publiser latest-tag

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -71,6 +71,10 @@ jobs:
           dockerfile: server/Dockerfile
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          tag: |
+            type=raw,value=latest,priority=9001
+            type=raw,value=${{ github.sha }},priority=9000
+          platforms: linux/amd64,linux/arm64
     outputs:
       image: ${{ steps.docker-push.outputs.image }}
 


### PR DESCRIPTION
Bygger Docker-imaget for både `linux/amd64` og `linux/arm64`, og publiserer en `latest`-tag i tillegg til sha-taggen.

Dette er samme oppsett som de andre melosys-repoene (faktureringskomponenten, melosys-trygdeavgift-beregning, melosys-dokgen, melosys-api) allerede har på `nais/docker-build-push`, men som dette repoet manglet. Uten arm64-variant må vi med Mac (Apple Silicon) kjøre imaget under emulering lokalt, og uten en `latest`-tag kommer det lokale oppsettet i melosys-docker-compose ut av synk ved neste deploy fordi det må pinne en tidsstemplet tag.

- Legger til `platforms: linux/amd64,linux/arm64` på `nais/docker-build-push`-steget
- Legger til `tag:` med `latest` (priority 9001) og `${{ github.sha }}` (priority 9000)

## Testing
- [ ] CI bygger og pusher imaget grønt
- [ ] `docker manifest inspect <image>:latest` viser både amd64 og arm64 etter deploy til main