### PR TITLE
8111: organisasjon ikke funnet warning

### DIFF
--- a/app/src/components/OrganisasjonSoker.tsx
+++ b/app/src/components/OrganisasjonSoker.tsx
@@ -60,8 +60,6 @@ export function OrganisasjonSoker({
 
   const formError = errors[formFieldName]?.message;
 
-  // En HTTP-feil (ikke ValideringError eller ingen feil) har statuskoden i
-  // meldingen, f.eks. "HTTP error! status: 404".
   const httpErrorMessage =
     query.isError && !(query.error instanceof ValideringError)
       ? query.error.message

--- a/app/src/components/OrganisasjonSoker.tsx
+++ b/app/src/components/OrganisasjonSoker.tsx
@@ -1,4 +1,4 @@
-import { Loader, TextField } from "@navikt/ds-react";
+import { Alert, Loader, TextField } from "@navikt/ds-react";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
@@ -60,20 +60,29 @@ export function OrganisasjonSoker({
 
   const formError = errors[formFieldName]?.message;
 
+  // En HTTP-feil (ikke ValideringError eller ingen feil) har statuskoden i
+  // meldingen, f.eks. "HTTP error! status: 404".
+  const httpErrorMessage =
+    query.isError && !(query.error instanceof ValideringError)
+      ? query.error.message
+      : null;
+  const statusMatch = httpErrorMessage?.match(/status:\s*(\d+)/);
+  const httpStatus = statusMatch ? statusMatch[1] : null;
+
+  // 404 = manglende treff: en forventet situasjon, ikke en systemfeil. Vises som
+  // egen warning-melding under feltet, ikke som rød feiltilstand i selve feltet.
+  const visIngenTreff = httpStatus === "404";
+
   const getErrorMessage = (): string | undefined => {
     if (query.isError) {
       if (query.error instanceof ValideringError) {
         return t("generellValidering.ugyldigOrganisasjonsnummer");
       }
-
-      const statusMatch = query.error.message.match(/status:\s*(\d+)/);
-      const status = statusMatch ? statusMatch[1] : null;
-
-      if (status === "429") {
+      if (httpStatus === "429") {
         return t("generellValidering.rateLimitOverskredet");
       }
-      if (status === "404") {
-        return t("generellValidering.organisasjonIkkeFunnet");
+      if (httpStatus === "404") {
+        return undefined; // vises som warning-melding via visIngenTreff
       }
       return t("generellValidering.feilVedSok");
     }
@@ -109,6 +118,17 @@ export function OrganisasjonSoker({
         <div aria-live="polite" className="mt-4" role="status">
           <Loader size="medium" title={t("felles.laster")} />
         </div>
+      )}
+
+      {visIngenTreff && !query.isFetching && (
+        <Alert
+          aria-live="polite"
+          className="mt-4"
+          size="small"
+          variant="warning"
+        >
+          {t("generellValidering.organisasjonIkkeFunnet")}
+        </Alert>
       )}
 
       {valgtOrganisasjon && !query.isFetching && (

--- a/app/tests/e2e/fixtures/api-mocks.ts
+++ b/app/tests/e2e/fixtures/api-mocks.ts
@@ -325,6 +325,27 @@ export async function mockGetEregOrganisasjonMedJuridiskEnhet(
   );
 }
 
+/**
+ * Mock der organisasjonsoppslaget gir 404 (manglende treff). Brukes for å teste
+ * at OrganisasjonSoker viser nøytral infotekst i stedet for rød feilboks.
+ */
+export async function mockGetEregOrganisasjonMedJuridiskEnhetIkkeFunnet(
+  page: Page,
+) {
+  await page.route(
+    "/api/ereg/organisasjon-med-juridisk-enhet/*",
+    async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Fant ingen organisasjon" }),
+        });
+      }
+    },
+  );
+}
+
 export async function setupApiMocksForArbeidsgiver(
   page: Page,
   skjema: UtsendtArbeidstakerSkjemaDto,

--- a/app/tests/e2e/pages/oversikt/oversikt.page.ts
+++ b/app/tests/e2e/pages/oversikt/oversikt.page.ts
@@ -231,6 +231,26 @@ export class OversiktPage {
     await expect(this.page.getByText(orgName)).toBeVisible();
   }
 
+  /** OrganisasjonSoker viser "fant ingen"-warning (404) */
+  async assertOrganisasjonIkkeFunnetIsVisible() {
+    await expect(
+      this.page.getByText(
+        translations.generellValidering.organisasjonIkkeFunnet,
+      ),
+    ).toBeVisible();
+  }
+
+  /**
+   * Org-feltet er IKKE i feiltilstand (rød boks). Skiller den nye
+   * warning-oppførselen fra den gamle feilboksen, som satte aria-invalid.
+   */
+  async assertArbeidsgiverOrgnrIkkeIFeiltilstand() {
+    await expect(this.arbeidsgiverOrgnrInput).not.toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  }
+
   /** Wait for the verifiser-person response to show verified person */
   async waitForPersonVerified(personName: string) {
     await expect(this.page.getByText(personName)).toBeVisible();

--- a/app/tests/e2e/specs/oversikt-validering.spec.ts
+++ b/app/tests/e2e/specs/oversikt-validering.spec.ts
@@ -2,6 +2,7 @@ import { Representasjonstype } from "~/types/melosysSkjemaTypes";
 
 import {
   mockGetEregOrganisasjonMedJuridiskEnhet,
+  mockGetEregOrganisasjonMedJuridiskEnhetIkkeFunnet,
   mockHentTilganger,
   mockPersonerMedFullmakt,
   setupApiMocksForOversikt,
@@ -41,6 +42,29 @@ test.describe("Oversikt - validering", () => {
 
     await oversiktPage.assertValideringManglerArbeidsgiverIsVisible();
     await oversiktPage.assertStillOnPage();
+  });
+
+  test("DEG_SELV: viser warning-melding (ikke rød feilboks) når organisasjonssøk gir 404", async ({
+    page,
+  }) => {
+    await setupApiMocksForOversikt(
+      page,
+      testUserInfo,
+      [],
+      emptyUtkastListe,
+      emptyInnsendteSoknader,
+    );
+    await mockGetEregOrganisasjonMedJuridiskEnhetIkkeFunnet(page);
+
+    const oversiktPage = new OversiktPage(page, Representasjonstype.DEG_SELV);
+    await oversiktPage.goto();
+    await oversiktPage.assertIsVisible();
+
+    await oversiktPage.fillArbeidsgiverOrgnr(korrektFormatertOrgnr);
+
+    // Manglende treff vises som warning-melding, og feltet er ikke i feiltilstand.
+    await oversiktPage.assertOrganisasjonIkkeFunnetIsVisible();
+    await oversiktPage.assertArbeidsgiverOrgnrIkkeIFeiltilstand();
   });
 
   test("ARBEIDSGIVER: viser feilmeldinger for manglende arbeidsgiver og arbeidstaker samtidig", async ({


### PR DESCRIPTION
Et 404-svar fra Ereg-oppslaget (organisasjonsnummer som ikke finnes) håndteres nå som en forventet situasjon, ikke en systemfeil. Brukeren får en warning-melding under feltet i stedet for rød feiltilstand.

Tidligere ble manglende treff vist som en rød feil, noe som er semantisk feil – brukeren har bare tastet inn et nummer som ikke finnes. Manglende treff skal verken se ut som «noe gikk galt» eller trigge alarm. Øvrige feil (ugyldig format, 429 rate-limit og generelle feil) vises fortsatt som feil på feltet.
[MELOSYS-8111](https://nav.atlassian.net/browse/MELOSYS-8111)

- 404 vises som `Alert variant="warning"` under feltet, ikke som feltfeil
- `getErrorMessage` returnerer `undefined` for 404 slik at feltet ikke settes i rød feiltilstand
- Ny e2e-dekning for manglende-treff-stien (404-mock + assertions som verifiserer warning + at feltet ikke er i feiltilstand)

## Testing
- [x] Manuell testing lokalt
- [x] E2E-tester (manglende-treff-sti, chromium)
