### PR TITLE
8109 Legg til e2e-test for auto-clear av til-dato

### DIFF
--- a/app/tests/e2e/specs/skjema/utsendingsperiode-og-land-validering.spec.ts
+++ b/app/tests/e2e/specs/skjema/utsendingsperiode-og-land-validering.spec.ts
@@ -1,5 +1,5 @@
 import { setupApiMocksForArbeidstaker } from "../../fixtures/api-mocks";
-import { test } from "../../fixtures/test";
+import { expect, test } from "../../fixtures/test";
 import {
   formFieldValues,
   testArbeidstakerSkjema,
@@ -64,5 +64,22 @@ test.describe("Utsendingsperiode og land - validering", () => {
     await stegPage.assertTilDatoForFraDatoFeilmeldingIsVisible();
     await stegPage.assertFraDatoErPakrevdIsNotVisible();
     await stegPage.assertTilDatoErPakrevdIsNotVisible();
+  });
+
+  test("tømmer til-dato uten umiddelbar påkrevd-feil når fra-dato settes etter til-dato", async () => {
+    await stegPage.velgLand(formFieldValues.utsendelseLand);
+    await stegPage.fillFraDato(formFieldValues.periodeFra);
+    await stegPage.fillTilDato(formFieldValues.periodeTil);
+    await expect(stegPage.tilDatoInput).toHaveValue(formFieldValues.periodeTil);
+
+    await stegPage.fraDatoInput.fill("01.01.2027");
+    await stegPage.fraDatoInput.blur();
+
+    await expect(stegPage.tilDatoInput).toHaveValue("");
+    await stegPage.assertTilDatoErPakrevdIsNotVisible();
+
+    await stegPage.lagreOgFortsett();
+
+    await stegPage.assertTilDatoErPakrevdIsVisible();
   });
 });


### PR DESCRIPTION
Legger til e2e-test for auto-clear av til-dato i utsendingsperiode-steget.

PR #505 innførte automatisk tømming av til-dato når fra-dato flyttes etter eksisterende til-dato, uten at brukeren får en umiddelbar påkrevd-feil. Denne testen sikrer regresjonsdekning for den flyten.
[MELOSYS-8109](https://jira.adeo.no/browse/MELOSYS-8109)

- Verifiserer at til-dato er fylt før fra-dato endres
- Verifiserer at til-dato tømmes når fra-dato settes etter til-dato
- Verifiserer at påkrevd-feil først vises etter forsøk på å gå videre

## Testing
- [ ] Enhetstester
- [ ] Manuell testing lokalt
- [x] E2E-tester