### PR TITLE
G4P: 8095 Konsekvent avrunding på forsidens paneler

### DIFF
--- a/app/src/pages/oversikt/components/InnsendteSoknaderTabell.tsx
+++ b/app/src/pages/oversikt/components/InnsendteSoknaderTabell.tsx
@@ -160,7 +160,7 @@ export function InnsendteSoknaderTabell({
   return (
     <Box
       background="neutral-soft"
-      borderRadius="2"
+      borderRadius="12"
       borderWidth="1"
       padding="space-24"
     >

--- a/app/src/pages/oversikt/components/SoknadStarter.tsx
+++ b/app/src/pages/oversikt/components/SoknadStarter.tsx
@@ -266,7 +266,7 @@ function SoknadStarterContent({
       <Box
         background="info-soft"
         borderColor="neutral-subtle"
-        borderRadius="2"
+        borderRadius="12"
         borderWidth="1"
         className="surface-action-subtle"
         padding="space-24"


### PR DESCRIPTION
Harmoniserer hjørne-avrundingen på forsidens paneler så de følger konsekvent Aksel-design.

Forsiden hadde paneler med ulik border-radius (2 vs 12), så noen så firkantede ut ved siden av avrundede. Setter alle topp-panelene til radius 12, som matcher BekreftelseBoks/GuidePanel og resten av skjemaet.
[MELOSYS-8095](https://nav.atlassian.net/browse/MELOSYS-8095)

- SoknadStarter-panelet: borderRadius 2 -> 12
- InnsendteSoknaderTabell (begge Box-er): borderRadius 2 -> 12

## Testing
- [x] Manuell testing lokalt (mobil 375px verifisert)
- [x] E2E-tester (representasjon/forside grønn)
