### PR TITLE
8170 Preutfyll arbeidsgivers orgnr på DEG_SELV-forsiden

### DIFF
--- a/app/src/pages/oversikt/components/SoknadStarter.tsx
+++ b/app/src/pages/oversikt/components/SoknadStarter.tsx
@@ -44,6 +44,7 @@ interface SoknadStarterProps {
 interface SoknadStarterContentProps {
   defaultData: SoknadStarterFormData;
   altinnArbeidsgivere: OrganisasjonDto[];
+  initialArbeidsgiverOrgnr?: string;
 }
 
 /**
@@ -148,6 +149,7 @@ export function SoknadStarter({ representasjonskontekst }: SoknadStarterProps) {
     <SoknadStarterContent
       altinnArbeidsgivere={arbeidsgivere ?? []}
       defaultData={defaultData}
+      initialArbeidsgiverOrgnr={representasjonskontekst.arbeidsgiverOrgnr}
       key={`${representasjonskontekst.representasjonstype}-${representasjonskontekst.radgiverOrgnr ?? ""}`}
     />
   );
@@ -159,6 +161,7 @@ export function SoknadStarter({ representasjonskontekst }: SoknadStarterProps) {
 function SoknadStarterContent({
   defaultData,
   altinnArbeidsgivere,
+  initialArbeidsgiverOrgnr,
 }: SoknadStarterContentProps) {
   const { t } = useTranslation();
   const translateError = useTranslateError();
@@ -202,6 +205,7 @@ function SoknadStarterContent({
       return (
         <OrganisasjonSoker
           formFieldName="arbeidsgiver"
+          initialOrgnr={initialArbeidsgiverOrgnr}
           label={t("oversiktFelles.arbeidsgiverOrgnrLabel")}
         />
       );

--- a/app/src/routes/oversikt.index.tsx
+++ b/app/src/routes/oversikt.index.tsx
@@ -34,6 +34,7 @@ function OversiktRoute() {
       representasjonskontekst={{
         representasjonstype: search.representasjonstype,
         radgiverOrgnr: search.radgiverOrgnr,
+        arbeidsgiverOrgnr: search.arbeidsgiverOrgnr,
       }}
     />
   );

--- a/app/src/types/representasjon.ts
+++ b/app/src/types/representasjon.ts
@@ -11,6 +11,7 @@ export const representasjonskontekstSchema = z.object({
     Representasjonstype.ANNEN_PERSON,
   ]),
   radgiverOrgnr: z.coerce.string().optional(),
+  arbeidsgiverOrgnr: z.coerce.string().optional(),
 });
 
 export type Representasjonskontekst = z.infer<


### PR DESCRIPTION
Arbeidstaker som følger varsel-lenken lander på DEG_SELV-forsiden med arbeidsgivers
organisasjonsnummer forhåndsutfylt, og slipper å taste det inn selv.

Når arbeidsgiver har sendt inn sin del uten fullmakt, får arbeidstaker en lenke i varselet
(bygget i melosys-skjema-api) som inneholder `representasjonstype=DEG_SELV&arbeidsgiverOrgnr=<orgnr>`.
Vi leser parameteren og mater den inn i den eksisterende `OrganisasjonSoker` via `initialOrgnr`,
som slår opp arbeidsgiveren og forhåndsutfyller feltet. Resten av flyten (bekreftelse +
«Start søknad») er uendret.
[MELOSYS-8170](https://nav.atlassian.net/browse/MELOSYS-8170)

- `representasjonskontekstSchema` tar imot valgfri `arbeidsgiverOrgnr`
- `/oversikt` sender parameteren videre til `SoknadStarter`
- `SoknadStarter` forhåndsutfyller `OrganisasjonSoker` for DEG_SELV via `initialOrgnr`
