### PR TITLE
MELOSYS-7933 Trigger E2E-tester etter deploy til dev

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -108,3 +108,28 @@ jobs:
           body: ${{ env.CHANGE_LOG }}
           draft: true
           prerelease: false
+
+  trigger-e2e-tests:
+    name: Trigger E2E tests
+    runs-on: ubuntu-latest
+    needs: [ build, deploy ]
+    if: always() && (needs.deploy.result == 'success' || needs.deploy.result == 'skipped')
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v7
+      - name: Get commit message
+        run: echo "COMMIT_MSG=$(git log --format=%s -n 1)" >> $GITHUB_ENV
+      - name: Trigger E2E tests in melosys-e2e-tests
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.E2E_TRIGGER_PAT }}
+          repository: navikt/melosys-e2e-tests
+          event-type: melosys-skjema-web-published
+          client-payload: |
+            {
+              "repository": "melosys-skjema-web",
+              "image_tag": "${{ github.sha }}",
+              "commit_sha": "${{ github.sha }}",
+              "commit_message": "${{ env.COMMIT_MSG }}",
+              "actor": "${{ github.actor }}"
+            }


### PR DESCRIPTION
## Hva
Etter vellykket deploy til dev sender `deploy-dev.yaml` en `repository_dispatch` til `navikt/melosys-e2e-tests` med event-type `melosys-skjema-web-published` og `image_tag=${{ github.sha }}`. E2E-suiten kjøres dermed automatisk mot det nettopp bygde imaget. Speiler mønsteret vi allerede har i melosys-api.

Kun ett nytt job (`trigger-e2e-tests`) — ingen andre endringer. Branchet ferskt fra `main`.

## Avhengigheter
- Krever at melosys-e2e-tests tar imot event-typen `melosys-skjema-web-published` — se navikt/melosys-e2e-tests#302. Uten den er dispatchen en no-op.
- Secret `E2E_TRIGGER_PAT` er allerede tilgjengelig i repoet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
