### PR TITLE
Legg til automerge av Dependabot-PRer

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,32 @@
+name: Dependabot Automerge
+
+on:
+  schedule:
+    - cron: '0 4 * * 1-5'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      statuses: read
+    steps:
+      - uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.CLIENT_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+      - name: Automerge Dependabot PRs
+        uses: navikt/automerge-dependabot@v1.5.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          blackout-periods: 'Sat,Sun,Dec 24-Jan 2'
+          semver-filter: 'patch,minor'
+          merge-method: 'squash'
+          # main krever at branchen er oppdatert før merge (strict status checks)
+          update-branch-before-merge: 'true'

--- a/.github/workflows/verify-app.yaml
+++ b/.github/workflows/verify-app.yaml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - 'main'
-    paths:
-      - 'app/**'
-      - '.github/*/verify-app.yaml'
 
 permissions:
   contents: read

--- a/.github/workflows/verify-server.yaml
+++ b/.github/workflows/verify-server.yaml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - 'main'
-    paths:
-      - 'server/**'
-      - '.github/*/verify-server.yaml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Samme oppsett som melosys-api og melosys-skjema-api (navikt/melosys-skjema-api#351).

- Kjører hverdager kl. 04 UTC (`workflow_dispatch` for manuell kjøring)
- `navikt/automerge-dependabot@v1.5.1` merger kun patch/minor, squash
- Blackout: helger og 24. des–2. jan
- GitHub App-token (`CLIENT_ID`/`PRIVATE_KEY` er lagt inn på repoet) slik at merge til main trigger deploy-dev
- `update-branch-before-merge` siden main krever oppdatert branch før merge

I tillegg fjernes path-filtrene på `verify: app` og `verify: server` slik at de kjører på alle PR-er mot main og trygt kan settes som required checks. Med filtrene ville en PR som ikke berører `app/` eller `server/` (f.eks. en github-actions-bump) blitt blokkert av sjekker som aldri rapporterer.