### PR TITLE
MELOSYS-8084 Motpart-CTA: banner på oversikten og hint på landingssiden

### DIFF
--- a/app/src/components/RepresentasjonVelger.tsx
+++ b/app/src/components/RepresentasjonVelger.tsx
@@ -5,11 +5,15 @@ import {
   PersonCircleIcon,
   PersonGroupIcon,
 } from "@navikt/aksel-icons";
-import { BodyShort, Heading, HStack } from "@navikt/ds-react";
+import { BodyShort, Heading, HStack, Tag } from "@navikt/ds-react";
+import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import type { ComponentType } from "react";
 import { useTranslation } from "react-i18next";
 
+import { MOTPART_CTA } from "~/featuretoggle/toggleNavn.ts";
+import { useFeatureToggle } from "~/featuretoggle/useFeatureToggle.ts";
+import { getVentendeMotpartSoknaderQuery } from "~/httpClients/melsosysSkjemaApiClient.ts";
 import { Representasjonstype } from "~/types/melosysSkjemaTypes.ts";
 import type { Representasjonskontekst } from "~/types/representasjon.ts";
 
@@ -27,9 +31,14 @@ interface RepresentationOption {
 interface RepresentationCardProps {
   option: RepresentationOption;
   onSelect: (type: Representasjonskontekst["representasjonstype"]) => void;
+  badge?: string;
 }
 
-function RepresentationCard({ option, onSelect }: RepresentationCardProps) {
+function RepresentationCard({
+  option,
+  onSelect,
+  badge,
+}: RepresentationCardProps) {
   const { t } = useTranslation();
   const Icon = option.icon;
 
@@ -47,7 +56,14 @@ function RepresentationCard({ option, onSelect }: RepresentationCardProps) {
             fontSize="1.75rem"
           />
           <div>
-            <BodyShort weight="semibold">{t(option.labelKey)}</BodyShort>
+            <HStack align="center" gap="space-8">
+              <BodyShort weight="semibold">{t(option.labelKey)}</BodyShort>
+              {badge && (
+                <Tag size="small" variant="info">
+                  {badge}
+                </Tag>
+              )}
+            </HStack>
             {option.descriptionKey && (
               <BodyShort size="small">{t(option.descriptionKey)}</BodyShort>
             )}
@@ -101,6 +117,14 @@ export function RepresentasjonVelger({
   const { t } = useTranslation();
   const navigate = useNavigate();
 
+  const motpartCtaAktiv = useFeatureToggle(MOTPART_CTA) ?? false;
+  const { data: ventendeMotpartSoknader } = useQuery({
+    ...getVentendeMotpartSoknaderQuery(),
+    enabled: motpartCtaAktiv,
+  });
+  const harVentendeMotpartSoknad =
+    (ventendeMotpartSoknader?.soknader.length ?? 0) > 0;
+
   const handleVelgRepresentasjon = (
     representasjonstype: Representasjonskontekst["representasjonstype"],
   ) => {
@@ -129,6 +153,12 @@ export function RepresentasjonVelger({
       <div className="flex flex-col gap-2">
         {REPRESENTATION_OPTIONS.map((option) => (
           <RepresentationCard
+            badge={
+              option.type === Representasjonstype.DEG_SELV &&
+              harVentendeMotpartSoknad
+                ? t("landingsside.soknadVenterPaaDeg")
+                : undefined
+            }
             key={option.type}
             onSelect={handleVelgRepresentasjon}
             option={option}

--- a/app/src/httpClients/melsosysSkjemaApiClient.ts
+++ b/app/src/httpClients/melsosysSkjemaApiClient.ts
@@ -27,6 +27,7 @@ import {
   UtsendtArbeidstakerSkjemaDto,
   VedleggDto,
   VedleggValgDto,
+  VentendeMotpartSoknaderResponse,
   VerifiserPersonRequest,
   VerifiserPersonResponse,
 } from "~/types/melosysSkjemaTypes.ts";
@@ -647,6 +648,34 @@ export async function slettVedlegg(
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);
   }
+}
+
+/**
+ * Innsendte arbeidsgiver-deler som venter på at innlogget bruker sender inn sin
+ * arbeidstaker-del. Tom liste når toggle `melosys.skjema.motpart-cta` er av i backend.
+ */
+export const getVentendeMotpartSoknaderQuery = () =>
+  queryOptions<VentendeMotpartSoknaderResponse>({
+    queryKey: ["ventende-motpart-soknader"],
+    queryFn: fetchVentendeMotpartSoknader,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    retry: 1,
+  });
+
+async function fetchVentendeMotpartSoknader(): Promise<VentendeMotpartSoknaderResponse> {
+  const response = await fetch(
+    `${API_PROXY_URL}/skjema/utsendt-arbeidstaker/ventende-motpart-soknader`,
+    {
+      method: "GET",
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response.json();
 }
 
 /**

--- a/app/src/httpClients/melsosysSkjemaApiClient.ts
+++ b/app/src/httpClients/melsosysSkjemaApiClient.ts
@@ -654,9 +654,13 @@ export async function slettVedlegg(
  * Innsendte arbeidsgiver-deler som venter på at innlogget bruker sender inn sin
  * arbeidstaker-del. Tom liste når toggle `melosys.skjema.motpart-cta` er av i backend.
  */
+export const VENTENDE_MOTPART_SOKNADER_QUERY_KEY = [
+  "ventende-motpart-soknader",
+] as const;
+
 export const getVentendeMotpartSoknaderQuery = () =>
   queryOptions<VentendeMotpartSoknaderResponse>({
-    queryKey: ["ventende-motpart-soknader"],
+    queryKey: VENTENDE_MOTPART_SOKNADER_QUERY_KEY,
     queryFn: fetchVentendeMotpartSoknader,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -413,6 +413,7 @@ export const en = {
         "filling out an application for employer/employee",
       annenPerson: "PRIVATE PERSON",
       annenPersonBeskrivelse: "filling out an application for another person",
+      soknadVenterPaaDeg: "An application is waiting for you",
       avbryt: "Cancel",
     },
     appHeader: {
@@ -438,6 +439,13 @@ export const en = {
       ettersendelseLenke: "Send documents to Nav",
       ettersendelseLenkeUrl:
         "https://www.nav.no/fyllut-ettersending/nav020807/innsendingsvalg",
+      motpartCtaTittel:
+        "{{arbeidsgiverNavn}} has submitted their part of the A1 application",
+      motpartCtaBeskrivelse:
+        "They have stated that you will be working abroad during the period {{fraDato}}–{{tilDato}}. For Nav to process the application, you must fill out your part.",
+      motpartCtaBeskrivelseUtenPeriode:
+        "For Nav to process the application, you must fill out your part.",
+      motpartCtaKnapp: "Fill out your part",
     },
     oversiktArbeidsgiver: {
       tittel: "Overview page for applications",

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -343,6 +343,9 @@ export const en = {
       tittel: "Posting period and country",
       duMaVelgeHvilketLandArbeidetSkalUtforesI:
         "You must select which country the work will be performed in",
+      preutfyltAvArbeidsgiver:
+        "Your employer has stated {{land}} and the period {{fraDato}}–{{tilDato}} in their part of the application. Check that the information is correct, and change it if anything is wrong.",
+      endreLandEllerPeriode: "Change country or period",
     },
     utenlandsoppdragetSteg: {
       tittel: "The Foreign Assignment",
@@ -440,9 +443,10 @@ export const en = {
       ettersendelseLenkeUrl:
         "https://www.nav.no/fyllut-ettersending/nav020807/innsendingsvalg",
       motpartCtaTittel:
-        "{{arbeidsgiverNavn}} has submitted their part of the A1 application",
+        "{{arbeidsgiverNavn}} has submitted their part of the application for A1 for workers posted in the EEA or Switzerland",
       motpartCtaBeskrivelse:
-        "They have stated that you will be working abroad during the period {{fraDato}}–{{tilDato}}. For Nav to process the application, you must fill out your part.",
+        "They have stated that you will be working in {{land}} during the period {{fraDato}}–{{tilDato}}. For Nav to process the application, you must fill out your part.",
+      motpartCtaUtlandetFallback: "abroad",
       motpartCtaBeskrivelseUtenPeriode:
         "For Nav to process the application, you must fill out your part.",
       motpartCtaKnapp: "Fill out your part",

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -346,6 +346,9 @@ export const en = {
       preutfyltAvArbeidsgiver:
         "Your employer has stated {{land}} and the period {{fraDato}}–{{tilDato}} in their part of the application. Check that the information is correct, and change it if anything is wrong.",
       endreLandEllerPeriode: "Change country or period",
+      arbeidsgiverOppgaLand: "Your employer stated {{land}}",
+      arbeidsgiverOppgaPeriode:
+        "Your employer stated the period {{fraDato}}–{{tilDato}}",
     },
     utenlandsoppdragetSteg: {
       tittel: "The Foreign Assignment",

--- a/app/src/i18n/nb.ts
+++ b/app/src/i18n/nb.ts
@@ -283,6 +283,9 @@ export const nb = {
       tittel: "Utsendingsperiode og land",
       duMaVelgeHvilketLandArbeidetSkalUtforesI:
         "Du må velge hvilket land arbeidet skal utføres i",
+      preutfyltAvArbeidsgiver:
+        "Arbeidsgiveren din har oppgitt {{land}} og perioden {{fraDato}}–{{tilDato}} i sin del av søknaden. Kontroller at opplysningene stemmer, og endre dem hvis noe er feil.",
+      endreLandEllerPeriode: "Endre land eller periode",
     },
     arbeidstakerenslonnSteg: {
       tittel: "Arbeidstakerens lønn",
@@ -330,9 +333,10 @@ export const nb = {
       ettersendelseLenkeUrl:
         "https://www.nav.no/fyllut-ettersending/nav020807/innsendingsvalg",
       motpartCtaTittel:
-        "{{arbeidsgiverNavn}} har sendt inn sin del av søknaden om A1",
+        "{{arbeidsgiverNavn}} har sendt inn sin del av søknaden om A1 for utsendte arbeidstakere i EØS eller Sveits",
       motpartCtaBeskrivelse:
-        "De har oppgitt at du skal jobbe i utlandet i perioden {{fraDato}}–{{tilDato}}. For at Nav skal kunne behandle søknaden, må du fylle ut din del.",
+        "De har oppgitt at du skal jobbe i {{land}} i perioden {{fraDato}}–{{tilDato}}. For at Nav skal kunne behandle søknaden, må du fylle ut din del.",
+      motpartCtaUtlandetFallback: "utlandet",
       motpartCtaBeskrivelseUtenPeriode:
         "For at Nav skal kunne behandle søknaden, må du fylle ut din del.",
       motpartCtaKnapp: "Fyll ut din del",

--- a/app/src/i18n/nb.ts
+++ b/app/src/i18n/nb.ts
@@ -303,6 +303,7 @@ export const nb = {
         "som fyller ut søknad for arbeidsgiver/arbeidstaker",
       annenPerson: "PRIVATPERSON",
       annenPersonBeskrivelse: "som fyller ut søknad for en annen person",
+      soknadVenterPaaDeg: "Søknad venter på deg",
       avbryt: "Avbryt",
     },
     appHeader: {
@@ -328,6 +329,13 @@ export const nb = {
       ettersendelseLenke: "Send dokumenter til Nav",
       ettersendelseLenkeUrl:
         "https://www.nav.no/fyllut-ettersending/nav020807/innsendingsvalg",
+      motpartCtaTittel:
+        "{{arbeidsgiverNavn}} har sendt inn sin del av søknaden om A1",
+      motpartCtaBeskrivelse:
+        "De har oppgitt at du skal jobbe i utlandet i perioden {{fraDato}}–{{tilDato}}. For at Nav skal kunne behandle søknaden, må du fylle ut din del.",
+      motpartCtaBeskrivelseUtenPeriode:
+        "For at Nav skal kunne behandle søknaden, må du fylle ut din del.",
+      motpartCtaKnapp: "Fyll ut din del",
     },
     oversiktArbeidsgiver: {
       tittel: "Oversiktsside for søknader",

--- a/app/src/i18n/nb.ts
+++ b/app/src/i18n/nb.ts
@@ -286,6 +286,9 @@ export const nb = {
       preutfyltAvArbeidsgiver:
         "Arbeidsgiveren din har oppgitt {{land}} og perioden {{fraDato}}–{{tilDato}} i sin del av søknaden. Kontroller at opplysningene stemmer, og endre dem hvis noe er feil.",
       endreLandEllerPeriode: "Endre land eller periode",
+      arbeidsgiverOppgaLand: "Arbeidsgiveren din oppga {{land}}",
+      arbeidsgiverOppgaPeriode:
+        "Arbeidsgiveren din oppga perioden {{fraDato}}–{{tilDato}}",
     },
     arbeidstakerenslonnSteg: {
       tittel: "Arbeidstakerens lønn",

--- a/app/src/pages/oversikt/OversiktPage.tsx
+++ b/app/src/pages/oversikt/OversiktPage.tsx
@@ -16,6 +16,7 @@ import {
   InnsendteSoknaderTabell,
   SoknadStarter,
   UtkastListe,
+  VentendeMotpartBanner,
 } from "~/pages/oversikt/components";
 import { Representasjonstype } from "~/types/melosysSkjemaTypes.ts";
 import type { Representasjonskontekst } from "~/types/representasjon.ts";
@@ -166,6 +167,9 @@ export function OversiktPage({ representasjonskontekst }: OversiktPageProps) {
           {getEttersendelseTekst()}
         </BodyShort>
       </GuidePanel>
+      <VentendeMotpartBanner
+        representasjonskontekst={representasjonskontekst}
+      />
       <UtkastListe representasjonskontekst={representasjonskontekst} />
       <SoknadStarter representasjonskontekst={representasjonskontekst} />
       <InnsendteSoknaderTabell

--- a/app/src/pages/oversikt/components/SoknadStarter.tsx
+++ b/app/src/pages/oversikt/components/SoknadStarter.tsx
@@ -133,6 +133,7 @@ export function SoknadStarter({ representasjonskontekst }: SoknadStarterProps) {
     representasjonstype: representasjonskontekst.representasjonstype,
     radgiverfirma,
     bekreftelse: false,
+    opprettetVia: representasjonskontekst.opprettetVia,
     // Setter default skalFylleUtForArbeidstaker:true for rådgiver, siden det er mest vanlig at de fyller ut på vegne av arbeidstaker.
     ...(representasjonskontekst.representasjonstype ===
       Representasjonstype.RADGIVER && {
@@ -150,7 +151,7 @@ export function SoknadStarter({ representasjonskontekst }: SoknadStarterProps) {
       altinnArbeidsgivere={arbeidsgivere ?? []}
       defaultData={defaultData}
       initialArbeidsgiverOrgnr={representasjonskontekst.arbeidsgiverOrgnr}
-      key={`${representasjonskontekst.representasjonstype}-${representasjonskontekst.radgiverOrgnr ?? ""}`}
+      key={`${representasjonskontekst.representasjonstype}-${representasjonskontekst.radgiverOrgnr ?? ""}-${representasjonskontekst.arbeidsgiverOrgnr ?? ""}`}
     />
   );
 }

--- a/app/src/pages/oversikt/components/SoknadStarter.tsx
+++ b/app/src/pages/oversikt/components/SoknadStarter.tsx
@@ -11,6 +11,7 @@ import {
 } from "@navikt/ds-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
@@ -139,6 +140,11 @@ export function SoknadStarter({ representasjonskontekst }: SoknadStarterProps) {
       Representasjonstype.DEG_SELV
         ? representasjonskontekst.opprettetVia
         : undefined,
+    prefyllFraSkjemaId:
+      representasjonskontekst.representasjonstype ===
+      Representasjonstype.DEG_SELV
+        ? representasjonskontekst.prefyllFraSkjemaId
+        : undefined,
     // Setter default skalFylleUtForArbeidstaker:true for rådgiver, siden det er mest vanlig at de fyller ut på vegne av arbeidstaker.
     ...(representasjonskontekst.representasjonstype ===
       Representasjonstype.RADGIVER && {
@@ -175,6 +181,13 @@ function SoknadStarterContent({
   const translateError = useTranslateError();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+
+  const boxRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (autoFocusArbeidsgiver) {
+      boxRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [autoFocusArbeidsgiver]);
 
   const formMethods = useForm({
     resolver: zodResolver(soknadStarterSchema),
@@ -263,14 +276,17 @@ function SoknadStarterContent({
   });
 
   const onSubmit = (data: SoknadStarterOutput) => {
-    // opprettetVia gjelder kun søknaden CTA-en pekte på — velger brukeren en
-    // annen arbeidsgiver enn den forhåndsutfylte, skal søknaden ikke tagges.
+    // opprettetVia og prefyll gjelder kun søknaden CTA-en pekte på — velger
+    // brukeren en annen arbeidsgiver enn den forhåndsutfylte, skal søknaden
+    // verken tagges eller forhåndsutfylles fra motpartens del.
+    const arbeidsgiverUendret =
+      data.arbeidsgiver.orgnr === initialOrganisasjon?.juridiskEnhet.orgnr;
     opprettSoknadMutation.mutate({
       ...data,
-      opprettetVia:
-        data.arbeidsgiver.orgnr === initialOrganisasjon?.juridiskEnhet.orgnr
-          ? data.opprettetVia
-          : undefined,
+      opprettetVia: arbeidsgiverUendret ? data.opprettetVia : undefined,
+      prefyllFraSkjemaId: arbeidsgiverUendret
+        ? data.prefyllFraSkjemaId
+        : undefined,
     });
   };
 
@@ -296,6 +312,7 @@ function SoknadStarterContent({
     <FormProvider {...formMethods}>
       <Box
         background="info-soft"
+        ref={boxRef}
         borderColor="neutral-subtle"
         borderRadius="12"
         borderWidth="1"

--- a/app/src/pages/oversikt/components/SoknadStarter.tsx
+++ b/app/src/pages/oversikt/components/SoknadStarter.tsx
@@ -21,8 +21,10 @@ import {
   getOrganisasjonMedJuridiskEnhetQuery,
   listAltinnTilganger,
   opprettSoknad,
+  VENTENDE_MOTPART_SOKNADER_QUERY_KEY,
 } from "~/httpClients/melsosysSkjemaApiClient.ts";
 import {
+  OpprettetVia,
   OrganisasjonDto,
   Representasjonstype,
 } from "~/types/melosysSkjemaTypes.ts";
@@ -185,7 +187,13 @@ function SoknadStarterContent({
   const boxRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (autoFocusArbeidsgiver) {
-      boxRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      const foretrekkerRedusertBevegelse = globalThis.matchMedia?.(
+        "(prefers-reduced-motion: reduce)",
+      ).matches;
+      boxRef.current?.scrollIntoView({
+        behavior: foretrekkerRedusertBevegelse ? "auto" : "smooth",
+        block: "start",
+      });
     }
   }, [autoFocusArbeidsgiver]);
 
@@ -266,7 +274,7 @@ function SoknadStarterContent({
     onSuccess: (data) => {
       void queryClient.invalidateQueries({ queryKey: ["utkast"] });
       void queryClient.invalidateQueries({
-        queryKey: ["ventende-motpart-soknader"],
+        queryKey: VENTENDE_MOTPART_SOKNADER_QUERY_KEY,
       });
       void navigate({
         to: "/skjema/$id",
@@ -276,14 +284,16 @@ function SoknadStarterContent({
   });
 
   const onSubmit = (data: SoknadStarterOutput) => {
-    // opprettetVia og prefyll gjelder kun søknaden CTA-en pekte på — velger
-    // brukeren en annen arbeidsgiver enn den forhåndsutfylte, skal søknaden
-    // verken tagges eller forhåndsutfylles fra motpartens del.
+    // CTA-taggen og prefyll gjelder kun søknaden CTA-en pekte på — velger
+    // brukeren en annen arbeidsgiver enn den forhåndsutfylte, regnes
+    // opprettelsen som ordinær og forhåndsutfylles ikke fra motpartens del.
     const arbeidsgiverUendret =
       data.arbeidsgiver.orgnr === initialOrganisasjon?.juridiskEnhet.orgnr;
     opprettSoknadMutation.mutate({
       ...data,
-      opprettetVia: arbeidsgiverUendret ? data.opprettetVia : undefined,
+      opprettetVia: arbeidsgiverUendret
+        ? data.opprettetVia
+        : OpprettetVia.ORDINAER,
       prefyllFraSkjemaId: arbeidsgiverUendret
         ? data.prefyllFraSkjemaId
         : undefined,

--- a/app/src/pages/oversikt/components/SoknadStarter.tsx
+++ b/app/src/pages/oversikt/components/SoknadStarter.tsx
@@ -45,6 +45,7 @@ interface SoknadStarterContentProps {
   defaultData: SoknadStarterFormData;
   altinnArbeidsgivere: OrganisasjonDto[];
   initialArbeidsgiverOrgnr?: string;
+  autoFocusArbeidsgiver?: boolean;
 }
 
 /**
@@ -133,7 +134,11 @@ export function SoknadStarter({ representasjonskontekst }: SoknadStarterProps) {
     representasjonstype: representasjonskontekst.representasjonstype,
     radgiverfirma,
     bekreftelse: false,
-    opprettetVia: representasjonskontekst.opprettetVia,
+    opprettetVia:
+      representasjonskontekst.representasjonstype ===
+      Representasjonstype.DEG_SELV
+        ? representasjonskontekst.opprettetVia
+        : undefined,
     // Setter default skalFylleUtForArbeidstaker:true for rådgiver, siden det er mest vanlig at de fyller ut på vegne av arbeidstaker.
     ...(representasjonskontekst.representasjonstype ===
       Representasjonstype.RADGIVER && {
@@ -149,6 +154,7 @@ export function SoknadStarter({ representasjonskontekst }: SoknadStarterProps) {
   return (
     <SoknadStarterContent
       altinnArbeidsgivere={arbeidsgivere ?? []}
+      autoFocusArbeidsgiver={!!representasjonskontekst.opprettetVia}
       defaultData={defaultData}
       initialArbeidsgiverOrgnr={representasjonskontekst.arbeidsgiverOrgnr}
       key={`${representasjonskontekst.representasjonstype}-${representasjonskontekst.radgiverOrgnr ?? ""}-${representasjonskontekst.arbeidsgiverOrgnr ?? ""}`}
@@ -163,6 +169,7 @@ function SoknadStarterContent({
   defaultData,
   altinnArbeidsgivere,
   initialArbeidsgiverOrgnr,
+  autoFocusArbeidsgiver = false,
 }: SoknadStarterContentProps) {
   const { t } = useTranslation();
   const translateError = useTranslateError();
@@ -205,6 +212,7 @@ function SoknadStarterContent({
     ) {
       return (
         <OrganisasjonSoker
+          autoFocus={autoFocusArbeidsgiver}
           formFieldName="arbeidsgiver"
           initialOrgnr={initialArbeidsgiverOrgnr}
           label={t("oversiktFelles.arbeidsgiverOrgnrLabel")}
@@ -233,10 +241,20 @@ function SoknadStarterContent({
     );
   }
 
+  // Samme oppslag som OrganisasjonSoker gjør for prefill-orgnr (cache-treff),
+  // siden skjemaverdien holder juridisk enhet-orgnr, ikke det prefylte orgnr.
+  const { data: initialOrganisasjon } = useQuery({
+    ...getOrganisasjonMedJuridiskEnhetQuery(initialArbeidsgiverOrgnr ?? ""),
+    enabled: !!initialArbeidsgiverOrgnr,
+  });
+
   const opprettSoknadMutation = useMutation({
     mutationFn: opprettSoknad,
     onSuccess: (data) => {
       void queryClient.invalidateQueries({ queryKey: ["utkast"] });
+      void queryClient.invalidateQueries({
+        queryKey: ["ventende-motpart-soknader"],
+      });
       void navigate({
         to: "/skjema/$id",
         params: { id: data.id },
@@ -245,7 +263,15 @@ function SoknadStarterContent({
   });
 
   const onSubmit = (data: SoknadStarterOutput) => {
-    opprettSoknadMutation.mutate(data);
+    // opprettetVia gjelder kun søknaden CTA-en pekte på — velger brukeren en
+    // annen arbeidsgiver enn den forhåndsutfylte, skal søknaden ikke tagges.
+    opprettSoknadMutation.mutate({
+      ...data,
+      opprettetVia:
+        data.arbeidsgiver.orgnr === initialOrganisasjon?.juridiskEnhet.orgnr
+          ? data.opprettetVia
+          : undefined,
+    });
   };
 
   // Samle feilmeldinger for visning

--- a/app/src/pages/oversikt/components/VentendeMotpartBanner.tsx
+++ b/app/src/pages/oversikt/components/VentendeMotpartBanner.tsx
@@ -1,0 +1,99 @@
+import { Alert, BodyLong, Button, Heading, VStack } from "@navikt/ds-react";
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+
+import { MOTPART_CTA } from "~/featuretoggle/toggleNavn.ts";
+import { useFeatureToggle } from "~/featuretoggle/useFeatureToggle.ts";
+import { getVentendeMotpartSoknaderQuery } from "~/httpClients/melsosysSkjemaApiClient.ts";
+import {
+  OpprettetVia,
+  Representasjonstype,
+  VentendeMotpartSoknadDto,
+} from "~/types/melosysSkjemaTypes.ts";
+import type { Representasjonskontekst } from "~/types/representasjon.ts";
+
+interface VentendeMotpartBannerProps {
+  representasjonskontekst: Representasjonskontekst;
+}
+
+const formatDato = (dato: string) =>
+  new Date(dato).toLocaleDateString("nb-NO", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+
+/**
+ * Oppfordring til arbeidstaker om å fylle ut sin del når arbeidsgiver allerede
+ * har sendt inn sin. Vises kun for DEG_SELV og bak toggle `melosys.skjema.motpart-cta`.
+ *
+ * Knappen navigerer til oversikten med arbeidsgivers orgnr forhåndsutfylt i
+ * søknadsstarteren; bekreftelsen må fortsatt hukes av som vanlig.
+ */
+export function VentendeMotpartBanner({
+  representasjonskontekst,
+}: VentendeMotpartBannerProps) {
+  const ctaAktiv = useFeatureToggle(MOTPART_CTA) ?? false;
+  const erDegSelv =
+    representasjonskontekst.representasjonstype ===
+    Representasjonstype.DEG_SELV;
+
+  const { data } = useQuery({
+    ...getVentendeMotpartSoknaderQuery(),
+    enabled: ctaAktiv && erDegSelv,
+  });
+
+  if (!ctaAktiv || !erDegSelv || !data || data.soknader.length === 0) {
+    return null;
+  }
+
+  return (
+    <VStack gap="space-16">
+      {data.soknader.map((soknad) => (
+        <VentendeMotpartAlert key={soknad.skjemaId} soknad={soknad} />
+      ))}
+    </VStack>
+  );
+}
+
+function VentendeMotpartAlert({
+  soknad,
+}: {
+  soknad: VentendeMotpartSoknadDto;
+}) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const startDinDel = () => {
+    void navigate({
+      to: "/oversikt",
+      search: {
+        representasjonstype: Representasjonstype.DEG_SELV,
+        arbeidsgiverOrgnr: soknad.arbeidsgiverOrgnr,
+        opprettetVia: OpprettetVia.MOTPART_CTA,
+      },
+    });
+  };
+
+  return (
+    <Alert variant="info">
+      <Heading level="2" size="small" spacing>
+        {t("oversiktDegSelv.motpartCtaTittel", {
+          arbeidsgiverNavn: soknad.arbeidsgiverNavn,
+        })}
+      </Heading>
+      <BodyLong spacing>
+        {soknad.utsendingsperiode
+          ? t("oversiktDegSelv.motpartCtaBeskrivelse", {
+              fraDato: formatDato(soknad.utsendingsperiode.fraDato),
+              tilDato: formatDato(soknad.utsendingsperiode.tilDato),
+            })
+          : t("oversiktDegSelv.motpartCtaBeskrivelseUtenPeriode")}
+      </BodyLong>
+      <Button onClick={startDinDel} size="small" variant="primary">
+        {t("oversiktDegSelv.motpartCtaKnapp")}
+      </Button>
+    </Alert>
+  );
+}

--- a/app/src/pages/oversikt/components/VentendeMotpartBanner.tsx
+++ b/app/src/pages/oversikt/components/VentendeMotpartBanner.tsx
@@ -66,6 +66,7 @@ function VentendeMotpartAlert({
         representasjonstype: Representasjonstype.DEG_SELV,
         arbeidsgiverOrgnr: soknad.arbeidsgiverOrgnr,
         opprettetVia: OpprettetVia.MOTPART_CTA,
+        prefyllFraSkjemaId: soknad.skjemaId,
       },
     });
   };
@@ -80,6 +81,9 @@ function VentendeMotpartAlert({
       <BodyLong spacing>
         {soknad.utsendingsperiode
           ? t("oversiktDegSelv.motpartCtaBeskrivelse", {
+              land: soknad.utsendelseLand
+                ? t(`land.${soknad.utsendelseLand}`)
+                : t("oversiktDegSelv.motpartCtaUtlandetFallback"),
               fraDato: formatDato(
                 soknad.utsendingsperiode.fraDato,
                 i18n.language,

--- a/app/src/pages/oversikt/components/VentendeMotpartBanner.tsx
+++ b/app/src/pages/oversikt/components/VentendeMotpartBanner.tsx
@@ -12,17 +12,11 @@ import {
   VentendeMotpartSoknadDto,
 } from "~/types/melosysSkjemaTypes.ts";
 import type { Representasjonskontekst } from "~/types/representasjon.ts";
+import { formatDato } from "~/utils/datoformat.ts";
 
 interface VentendeMotpartBannerProps {
   representasjonskontekst: Representasjonskontekst;
 }
-
-const formatDato = (dato: string) =>
-  new Date(dato).toLocaleDateString("nb-NO", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  });
 
 /**
  * Oppfordring til arbeidstaker om å fylle ut sin del når arbeidsgiver allerede
@@ -62,7 +56,7 @@ function VentendeMotpartAlert({
 }: {
   soknad: VentendeMotpartSoknadDto;
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
 
   const startDinDel = () => {
@@ -86,8 +80,14 @@ function VentendeMotpartAlert({
       <BodyLong spacing>
         {soknad.utsendingsperiode
           ? t("oversiktDegSelv.motpartCtaBeskrivelse", {
-              fraDato: formatDato(soknad.utsendingsperiode.fraDato),
-              tilDato: formatDato(soknad.utsendingsperiode.tilDato),
+              fraDato: formatDato(
+                soknad.utsendingsperiode.fraDato,
+                i18n.language,
+              ),
+              tilDato: formatDato(
+                soknad.utsendingsperiode.tilDato,
+                i18n.language,
+              ),
             })
           : t("oversiktDegSelv.motpartCtaBeskrivelseUtenPeriode")}
       </BodyLong>

--- a/app/src/pages/oversikt/components/index.ts
+++ b/app/src/pages/oversikt/components/index.ts
@@ -3,3 +3,4 @@ export { ArbeidstakerVelger } from "./ArbeidstakerVelger.tsx";
 export { InnsendteSoknaderTabell } from "./InnsendteSoknaderTabell.tsx";
 export { SoknadStarter } from "./SoknadStarter.tsx";
 export { UtkastListe } from "./UtkastListe.tsx";
+export { VentendeMotpartBanner } from "./VentendeMotpartBanner.tsx";

--- a/app/src/pages/oversikt/components/soknadStarterSchema.ts
+++ b/app/src/pages/oversikt/components/soknadStarterSchema.ts
@@ -40,6 +40,7 @@ export const soknadStarterSchema = z
     skalFylleUtForArbeidstaker: z.boolean().optional(),
     bekreftelse: z.boolean(),
     opprettetVia: z.enum(OpprettetVia).optional(),
+    prefyllFraSkjemaId: z.string().optional(),
   })
   .refine((data) => !!data.arbeidsgiver, {
     error: "oversiktFelles.valideringManglerArbeidsgiver",
@@ -71,6 +72,7 @@ export const soknadStarterSchema = z
       arbeidsgiver: data.arbeidsgiver!,
       arbeidstaker: data.arbeidstaker!,
       opprettetVia: data.opprettetVia,
+      prefyllFraSkjemaId: data.prefyllFraSkjemaId,
     };
   });
 

--- a/app/src/pages/oversikt/components/soknadStarterSchema.ts
+++ b/app/src/pages/oversikt/components/soknadStarterSchema.ts
@@ -40,7 +40,7 @@ export const soknadStarterSchema = z
     skalFylleUtForArbeidstaker: z.boolean().optional(),
     bekreftelse: z.boolean(),
     opprettetVia: z.enum(OpprettetVia).optional(),
-    prefyllFraSkjemaId: z.string().optional(),
+    prefyllFraSkjemaId: z.uuid().optional(),
   })
   .refine((data) => !!data.arbeidsgiver, {
     error: "oversiktFelles.valideringManglerArbeidsgiver",
@@ -71,7 +71,7 @@ export const soknadStarterSchema = z
       radgiverfirma: data.radgiverfirma,
       arbeidsgiver: data.arbeidsgiver!,
       arbeidstaker: data.arbeidstaker!,
-      opprettetVia: data.opprettetVia,
+      opprettetVia: data.opprettetVia ?? OpprettetVia.ORDINAER,
       prefyllFraSkjemaId: data.prefyllFraSkjemaId,
     };
   });

--- a/app/src/pages/oversikt/components/soknadStarterSchema.ts
+++ b/app/src/pages/oversikt/components/soknadStarterSchema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import {
+  OpprettetVia,
   OpprettUtsendtArbeidstakerSoknadRequest,
   Representasjonstype,
 } from "~/types/melosysSkjemaTypes.ts";
@@ -38,6 +39,7 @@ export const soknadStarterSchema = z
       .optional(),
     skalFylleUtForArbeidstaker: z.boolean().optional(),
     bekreftelse: z.boolean(),
+    opprettetVia: z.enum(OpprettetVia).optional(),
   })
   .refine((data) => !!data.arbeidsgiver, {
     error: "oversiktFelles.valideringManglerArbeidsgiver",
@@ -68,6 +70,7 @@ export const soknadStarterSchema = z
       radgiverfirma: data.radgiverfirma,
       arbeidsgiver: data.arbeidsgiver!,
       arbeidstaker: data.arbeidstaker!,
+      opprettetVia: data.opprettetVia,
     };
   });
 

--- a/app/src/pages/skjema/components/SendInnSkjemaKnapp.tsx
+++ b/app/src/pages/skjema/components/SendInnSkjemaKnapp.tsx
@@ -8,6 +8,7 @@ import {
   getInnsendtKvitteringQuery,
   getSkjemaQuery,
   sendInnSkjema,
+  VENTENDE_MOTPART_SOKNADER_QUERY_KEY,
 } from "~/httpClients/melsosysSkjemaApiClient.ts";
 
 interface SendInnSkjemaKnappProps {
@@ -47,7 +48,7 @@ export function SendInnSkjemaKnapp({
       });
 
       void queryClient.invalidateQueries({
-        queryKey: ["ventende-motpart-soknader"],
+        queryKey: VENTENDE_MOTPART_SOKNADER_QUERY_KEY,
       });
 
       navigate({

--- a/app/src/pages/skjema/components/SendInnSkjemaKnapp.tsx
+++ b/app/src/pages/skjema/components/SendInnSkjemaKnapp.tsx
@@ -46,6 +46,10 @@ export function SendInnSkjemaKnapp({
         queryKey: ["utkast"],
       });
 
+      void queryClient.invalidateQueries({
+        queryKey: ["ventende-motpart-soknader"],
+      });
+
       navigate({
         to: "/skjema/$id/kvittering",
         params: { id: response.skjemaId },

--- a/app/src/pages/skjema/utsendingsperiode-og-land/UtsendingsperiodeOgLandSteg.tsx
+++ b/app/src/pages/skjema/utsendingsperiode-og-land/UtsendingsperiodeOgLandSteg.tsx
@@ -1,7 +1,10 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Alert, BodyShort, Button, Label } from "@navikt/ds-react";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 
 import { PeriodeFormPart } from "~/components/date/PeriodeFormPart.tsx";
 import { LandVelgerFormPart } from "~/components/LandVelgerFormPart.tsx";
@@ -21,6 +24,7 @@ import type {
   UtsendingsperiodeOgLandDto,
   UtsendtArbeidstakerSkjemaDto,
 } from "~/types/melosysSkjemaTypes.ts";
+import { formatDato } from "~/utils/datoformat.ts";
 
 import { SkjemaStegLoader } from "../components/SkjemaStegLoader.tsx";
 import { getUtsendingsperiodeOgLand } from "../stegDataGetters.ts";
@@ -37,6 +41,7 @@ function UtsendingsperiodeOgLandStegContent({
 }) {
   const stegRekkefolge = STEG_REKKEFOLGE[skjema.metadata.skjemadel];
   const stegData = getUtsendingsperiodeOgLand(skjema);
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const invalidateSkjemaQuery = useInvalidateSkjemaQuery();
   const { getFelt } = useSkjemaDefinisjon();
@@ -49,6 +54,19 @@ function UtsendingsperiodeOgLandStegContent({
     "utsendingsperiodeOgLand",
     "utsendelsePeriode",
   );
+
+  const motpartensVerdier = skjema.motpartensUtsendingsperiodeOgLand;
+  const erUendretFraMotpart =
+    !!motpartensVerdier &&
+    stegData?.utsendelseLand === motpartensVerdier.utsendelseLand &&
+    stegData.utsendelsePeriode?.fraDato ===
+      motpartensVerdier.utsendelsePeriode.fraDato &&
+    stegData.utsendelsePeriode?.tilDato ===
+      motpartensVerdier.utsendelsePeriode.tilDato;
+  const [redigerer, setRedigerer] = useState(false);
+  // Motpartens verdier vises som lesevisning til bruker aktivt velger å endre,
+  // så ingen justerer dato eller land ved et uhell
+  const visLesevisning = erUendretFraMotpart && !redigerer;
 
   const formMethods = useForm({
     resolver: zodResolver(utsendingsperiodeOgLandSchema),
@@ -106,30 +124,76 @@ function UtsendingsperiodeOgLandStegContent({
             />
           }
         >
-          <LandVelgerFormPart
-            className="mt-4"
-            formFieldName="utsendelseLand"
-            label={utsendelseLandFelt.label}
-          />
+          {skjema.motpartensUtsendingsperiodeOgLand && (
+            <Alert className="mt-4" variant="info">
+              {t("utsendingsperiodeOgLandSteg.preutfyltAvArbeidsgiver", {
+                land: t(
+                  `land.${skjema.motpartensUtsendingsperiodeOgLand.utsendelseLand}`,
+                ),
+                fraDato: formatDato(
+                  skjema.motpartensUtsendingsperiodeOgLand.utsendelsePeriode
+                    .fraDato,
+                  i18n.language,
+                ),
+                tilDato: formatDato(
+                  skjema.motpartensUtsendingsperiodeOgLand.utsendelsePeriode
+                    .tilDato,
+                  i18n.language,
+                ),
+              })}
+            </Alert>
+          )}
 
-          <PeriodeFormPart
-            className="mt-6"
-            defaultFraDato={
-              stegData?.utsendelsePeriode?.fraDato
-                ? new Date(stegData.utsendelsePeriode.fraDato)
-                : undefined
-            }
-            defaultTilDato={
-              stegData?.utsendelsePeriode?.tilDato
-                ? new Date(stegData.utsendelsePeriode.tilDato)
-                : undefined
-            }
-            defaultTilMåned={formFraDato ? new Date(formFraDato) : undefined}
-            formFieldName="utsendelsePeriode"
-            label={utsendelsePeriodeFelt.label}
-            tilDatoDescription={utsendelsePeriodeFelt.hjelpetekst}
-            {...dateLimits}
-          />
+          {visLesevisning && stegData ? (
+            <div className="mt-6">
+              <Label as="p">{utsendelseLandFelt.label}</Label>
+              <BodyShort spacing>
+                {t(`land.${stegData.utsendelseLand}`)}
+              </BodyShort>
+              <Label as="p">{utsendelsePeriodeFelt.label}</Label>
+              <BodyShort spacing>
+                {formatDato(stegData.utsendelsePeriode.fraDato, i18n.language)}–
+                {formatDato(stegData.utsendelsePeriode.tilDato, i18n.language)}
+              </BodyShort>
+              <Button
+                onClick={() => setRedigerer(true)}
+                size="small"
+                type="button"
+                variant="secondary"
+              >
+                {t("utsendingsperiodeOgLandSteg.endreLandEllerPeriode")}
+              </Button>
+            </div>
+          ) : (
+            <>
+              <LandVelgerFormPart
+                className="mt-4"
+                formFieldName="utsendelseLand"
+                label={utsendelseLandFelt.label}
+              />
+
+              <PeriodeFormPart
+                className="mt-6"
+                defaultFraDato={
+                  stegData?.utsendelsePeriode?.fraDato
+                    ? new Date(stegData.utsendelsePeriode.fraDato)
+                    : undefined
+                }
+                defaultTilDato={
+                  stegData?.utsendelsePeriode?.tilDato
+                    ? new Date(stegData.utsendelsePeriode.tilDato)
+                    : undefined
+                }
+                defaultTilMåned={
+                  formFraDato ? new Date(formFraDato) : undefined
+                }
+                formFieldName="utsendelsePeriode"
+                label={utsendelsePeriodeFelt.label}
+                tilDatoDescription={utsendelsePeriodeFelt.hjelpetekst}
+                {...dateLimits}
+              />
+            </>
+          )}
         </SkjemaSteg>
       </form>
     </FormProvider>

--- a/app/src/pages/skjema/utsendingsperiode-og-land/UtsendingsperiodeOgLandSteg.tsx
+++ b/app/src/pages/skjema/utsendingsperiode-og-land/UtsendingsperiodeOgLandSteg.tsx
@@ -75,6 +75,18 @@ function UtsendingsperiodeOgLandStegContent({
 
   const { handleSubmit, watch } = formMethods;
   const formFraDato = watch("utsendelsePeriode.fraDato");
+  const formTilDato = watch("utsendelsePeriode.tilDato");
+  const formLand = watch("utsendelseLand");
+
+  const landAvviker =
+    !!motpartensVerdier &&
+    !!formLand &&
+    formLand !== motpartensVerdier.utsendelseLand;
+  const periodeAvviker =
+    !!motpartensVerdier &&
+    !!(formFraDato || formTilDato) &&
+    (formFraDato !== motpartensVerdier.utsendelsePeriode.fraDato ||
+      formTilDato !== motpartensVerdier.utsendelsePeriode.tilDato);
 
   const dateLimits = {
     // Dato norge ble EØS medlem
@@ -124,20 +136,16 @@ function UtsendingsperiodeOgLandStegContent({
             />
           }
         >
-          {skjema.motpartensUtsendingsperiodeOgLand && (
+          {motpartensVerdier && (
             <Alert className="mt-4" variant="info">
               {t("utsendingsperiodeOgLandSteg.preutfyltAvArbeidsgiver", {
-                land: t(
-                  `land.${skjema.motpartensUtsendingsperiodeOgLand.utsendelseLand}`,
-                ),
+                land: t(`land.${motpartensVerdier.utsendelseLand}`),
                 fraDato: formatDato(
-                  skjema.motpartensUtsendingsperiodeOgLand.utsendelsePeriode
-                    .fraDato,
+                  motpartensVerdier.utsendelsePeriode.fraDato,
                   i18n.language,
                 ),
                 tilDato: formatDato(
-                  skjema.motpartensUtsendingsperiodeOgLand.utsendelsePeriode
-                    .tilDato,
+                  motpartensVerdier.utsendelsePeriode.tilDato,
                   i18n.language,
                 ),
               })}
@@ -171,6 +179,13 @@ function UtsendingsperiodeOgLandStegContent({
                 formFieldName="utsendelseLand"
                 label={utsendelseLandFelt.label}
               />
+              {landAvviker && (
+                <Alert className="mt-2" inline size="small" variant="info">
+                  {t("utsendingsperiodeOgLandSteg.arbeidsgiverOppgaLand", {
+                    land: t(`land.${motpartensVerdier.utsendelseLand}`),
+                  })}
+                </Alert>
+              )}
 
               <PeriodeFormPart
                 className="mt-6"
@@ -192,6 +207,20 @@ function UtsendingsperiodeOgLandStegContent({
                 tilDatoDescription={utsendelsePeriodeFelt.hjelpetekst}
                 {...dateLimits}
               />
+              {periodeAvviker && (
+                <Alert className="mt-2" inline size="small" variant="info">
+                  {t("utsendingsperiodeOgLandSteg.arbeidsgiverOppgaPeriode", {
+                    fraDato: formatDato(
+                      motpartensVerdier.utsendelsePeriode.fraDato,
+                      i18n.language,
+                    ),
+                    tilDato: formatDato(
+                      motpartensVerdier.utsendelsePeriode.tilDato,
+                      i18n.language,
+                    ),
+                  })}
+                </Alert>
+              )}
             </>
           )}
         </SkjemaSteg>

--- a/app/src/pages/skjema/utsendingsperiode-og-land/UtsendingsperiodeOgLandSteg.tsx
+++ b/app/src/pages/skjema/utsendingsperiode-og-land/UtsendingsperiodeOgLandSteg.tsx
@@ -24,7 +24,7 @@ import type {
   UtsendingsperiodeOgLandDto,
   UtsendtArbeidstakerSkjemaDto,
 } from "~/types/melosysSkjemaTypes.ts";
-import { formatDato } from "~/utils/datoformat.ts";
+import { formatDato, parseIsoDato } from "~/utils/datoformat.ts";
 
 import { SkjemaStegLoader } from "../components/SkjemaStegLoader.tsx";
 import { getUtsendingsperiodeOgLand } from "../stegDataGetters.ts";
@@ -84,7 +84,8 @@ function UtsendingsperiodeOgLandStegContent({
     formLand !== motpartensVerdier.utsendelseLand;
   const periodeAvviker =
     !!motpartensVerdier &&
-    !!(formFraDato || formTilDato) &&
+    !!formFraDato &&
+    !!formTilDato &&
     (formFraDato !== motpartensVerdier.utsendelsePeriode.fraDato ||
       formTilDato !== motpartensVerdier.utsendelsePeriode.tilDato);
 
@@ -154,15 +155,30 @@ function UtsendingsperiodeOgLandStegContent({
 
           {visLesevisning && stegData ? (
             <div className="mt-6">
-              <Label as="p">{utsendelseLandFelt.label}</Label>
-              <BodyShort spacing>
-                {t(`land.${stegData.utsendelseLand}`)}
-              </BodyShort>
-              <Label as="p">{utsendelsePeriodeFelt.label}</Label>
-              <BodyShort spacing>
-                {formatDato(stegData.utsendelsePeriode.fraDato, i18n.language)}–
-                {formatDato(stegData.utsendelsePeriode.tilDato, i18n.language)}
-              </BodyShort>
+              <dl>
+                <dt>
+                  <Label as="span">{utsendelseLandFelt.label}</Label>
+                </dt>
+                <dd className="mb-4">
+                  <BodyShort>{t(`land.${stegData.utsendelseLand}`)}</BodyShort>
+                </dd>
+                <dt>
+                  <Label as="span">{utsendelsePeriodeFelt.label}</Label>
+                </dt>
+                <dd className="mb-4">
+                  <BodyShort>
+                    {formatDato(
+                      stegData.utsendelsePeriode.fraDato,
+                      i18n.language,
+                    )}
+                    –
+                    {formatDato(
+                      stegData.utsendelsePeriode.tilDato,
+                      i18n.language,
+                    )}
+                  </BodyShort>
+                </dd>
+              </dl>
               <Button
                 onClick={() => setRedigerer(true)}
                 size="small"
@@ -175,6 +191,7 @@ function UtsendingsperiodeOgLandStegContent({
           ) : (
             <>
               <LandVelgerFormPart
+                autoFocus={redigerer}
                 className="mt-4"
                 formFieldName="utsendelseLand"
                 label={utsendelseLandFelt.label}
@@ -191,16 +208,16 @@ function UtsendingsperiodeOgLandStegContent({
                 className="mt-6"
                 defaultFraDato={
                   stegData?.utsendelsePeriode?.fraDato
-                    ? new Date(stegData.utsendelsePeriode.fraDato)
+                    ? parseIsoDato(stegData.utsendelsePeriode.fraDato)
                     : undefined
                 }
                 defaultTilDato={
                   stegData?.utsendelsePeriode?.tilDato
-                    ? new Date(stegData.utsendelsePeriode.tilDato)
+                    ? parseIsoDato(stegData.utsendelsePeriode.tilDato)
                     : undefined
                 }
                 defaultTilMåned={
-                  formFraDato ? new Date(formFraDato) : undefined
+                  formFraDato ? parseIsoDato(formFraDato) : undefined
                 }
                 formFieldName="utsendelsePeriode"
                 label={utsendelsePeriodeFelt.label}

--- a/app/src/routes/oversikt.index.tsx
+++ b/app/src/routes/oversikt.index.tsx
@@ -36,6 +36,7 @@ function OversiktRoute() {
         radgiverOrgnr: search.radgiverOrgnr,
         arbeidsgiverOrgnr: search.arbeidsgiverOrgnr,
         opprettetVia: search.opprettetVia,
+        prefyllFraSkjemaId: search.prefyllFraSkjemaId,
       }}
     />
   );

--- a/app/src/routes/oversikt.index.tsx
+++ b/app/src/routes/oversikt.index.tsx
@@ -35,6 +35,7 @@ function OversiktRoute() {
         representasjonstype: search.representasjonstype,
         radgiverOrgnr: search.radgiverOrgnr,
         arbeidsgiverOrgnr: search.arbeidsgiverOrgnr,
+        opprettetVia: search.opprettetVia,
       }}
     />
   );

--- a/app/src/types/melosysSkjemaTypes.ts
+++ b/app/src/types/melosysSkjemaTypes.ts
@@ -46,6 +46,11 @@ export enum SorteringsFelt {
   STATUS = "STATUS",
 }
 
+export enum OpprettetVia {
+  MOTPART_CTA = "MOTPART_CTA",
+  ORDINAER = "ORDINAER",
+}
+
 export enum TypeInnretning {
   PLATTFORM_ELLER_ANNEN_FAST_INNRETNING = "PLATTFORM_ELLER_ANNEN_FAST_INNRETNING",
   BORESKIP_ELLER_ANNEN_FLYTTBAR_INNRETNING = "BORESKIP_ELLER_ANNEN_FLYTTBAR_INNRETNING",
@@ -74,10 +79,6 @@ export enum Representasjonstype {
   RADGIVER = "RADGIVER",
   RADGIVER_MED_FULLMAKT = "RADGIVER_MED_FULLMAKT",
   ANNEN_PERSON = "ANNEN_PERSON",
-}
-
-export enum OpprettetVia {
-  MOTPART_CTA = "MOTPART_CTA",
 }
 
 export enum LandKode {
@@ -528,9 +529,9 @@ export interface UtsendtArbeidstakerMetadata {
 }
 
 export interface UtsendtArbeidstakerSkjemaData {
-  tilleggsopplysninger?: TilleggsopplysningerDto;
   utsendingsperiodeOgLand?: UtsendingsperiodeOgLandDto;
   vedlegg?: VedleggValgDto;
+  tilleggsopplysninger?: TilleggsopplysningerDto;
   type: string;
 }
 
@@ -556,7 +557,6 @@ export interface UtsendtArbeidstakerSkjemaDto {
     | UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto
     | UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
     | UtsendtArbeidstakerArbeidstakersSkjemaDataDto;
-  opprettetVia?: OpprettetVia;
   motpartensUtsendingsperiodeOgLand?: UtsendingsperiodeOgLandDto;
 }
 
@@ -572,7 +572,7 @@ export interface OpprettUtsendtArbeidstakerSoknadRequest {
   radgiverfirma?: SimpleOrganisasjonDto;
   arbeidsgiver: SimpleOrganisasjonDto;
   arbeidstaker: PersonDto;
-  opprettetVia?: OpprettetVia;
+  opprettetVia: OpprettetVia;
   /** @format uuid */
   prefyllFraSkjemaId?: string;
 }

--- a/app/src/types/melosysSkjemaTypes.ts
+++ b/app/src/types/melosysSkjemaTypes.ts
@@ -46,10 +46,6 @@ export enum SorteringsFelt {
   STATUS = "STATUS",
 }
 
-export enum OpprettetVia {
-  MOTPART_CTA = "MOTPART_CTA",
-}
-
 export enum TypeInnretning {
   PLATTFORM_ELLER_ANNEN_FAST_INNRETNING = "PLATTFORM_ELLER_ANNEN_FAST_INNRETNING",
   BORESKIP_ELLER_ANNEN_FLYTTBAR_INNRETNING = "BORESKIP_ELLER_ANNEN_FLYTTBAR_INNRETNING",
@@ -78,6 +74,10 @@ export enum Representasjonstype {
   RADGIVER = "RADGIVER",
   RADGIVER_MED_FULLMAKT = "RADGIVER_MED_FULLMAKT",
   ANNEN_PERSON = "ANNEN_PERSON",
+}
+
+export enum OpprettetVia {
+  MOTPART_CTA = "MOTPART_CTA",
 }
 
 export enum LandKode {
@@ -528,9 +528,9 @@ export interface UtsendtArbeidstakerMetadata {
 }
 
 export interface UtsendtArbeidstakerSkjemaData {
+  tilleggsopplysninger?: TilleggsopplysningerDto;
   utsendingsperiodeOgLand?: UtsendingsperiodeOgLandDto;
   vedlegg?: VedleggValgDto;
-  tilleggsopplysninger?: TilleggsopplysningerDto;
   type: string;
 }
 
@@ -556,6 +556,8 @@ export interface UtsendtArbeidstakerSkjemaDto {
     | UtsendtArbeidstakerArbeidsgiverOgArbeidstakerSkjemaDataDto
     | UtsendtArbeidstakerArbeidsgiversSkjemaDataDto
     | UtsendtArbeidstakerArbeidstakersSkjemaDataDto;
+  opprettetVia?: OpprettetVia;
+  motpartensUtsendingsperiodeOgLand?: UtsendingsperiodeOgLandDto;
 }
 
 export interface SkjemaInnsendtKvittering {
@@ -571,6 +573,8 @@ export interface OpprettUtsendtArbeidstakerSoknadRequest {
   arbeidsgiver: SimpleOrganisasjonDto;
   arbeidstaker: PersonDto;
   opprettetVia?: OpprettetVia;
+  /** @format uuid */
+  prefyllFraSkjemaId?: string;
 }
 
 export interface PersonDto {
@@ -882,6 +886,7 @@ export interface VentendeMotpartSoknadDto {
   arbeidsgiverNavn: string;
   arbeidsgiverOrgnr: string;
   utsendingsperiode?: PeriodeDto;
+  utsendelseLand?: LandKode;
   /** @format date-time */
   innsendtDato: string;
 }

--- a/app/src/types/melosysSkjemaTypes.ts
+++ b/app/src/types/melosysSkjemaTypes.ts
@@ -46,6 +46,10 @@ export enum SorteringsFelt {
   STATUS = "STATUS",
 }
 
+export enum OpprettetVia {
+  MOTPART_CTA = "MOTPART_CTA",
+}
+
 export enum TypeInnretning {
   PLATTFORM_ELLER_ANNEN_FAST_INNRETNING = "PLATTFORM_ELLER_ANNEN_FAST_INNRETNING",
   BORESKIP_ELLER_ANNEN_FLYTTBAR_INNRETNING = "BORESKIP_ELLER_ANNEN_FLYTTBAR_INNRETNING",
@@ -524,8 +528,8 @@ export interface UtsendtArbeidstakerMetadata {
 }
 
 export interface UtsendtArbeidstakerSkjemaData {
-  vedlegg?: VedleggValgDto;
   utsendingsperiodeOgLand?: UtsendingsperiodeOgLandDto;
+  vedlegg?: VedleggValgDto;
   tilleggsopplysninger?: TilleggsopplysningerDto;
   type: string;
 }
@@ -566,6 +570,7 @@ export interface OpprettUtsendtArbeidstakerSoknadRequest {
   radgiverfirma?: SimpleOrganisasjonDto;
   arbeidsgiver: SimpleOrganisasjonDto;
   arbeidstaker: PersonDto;
+  opprettetVia?: OpprettetVia;
 }
 
 export interface PersonDto {
@@ -870,6 +875,20 @@ export type TextareaFeltDefinisjon = UtilRequiredKeys<
   /** @format int32 */
   maxLength?: number;
 };
+
+export interface VentendeMotpartSoknadDto {
+  /** @format uuid */
+  skjemaId: string;
+  arbeidsgiverNavn: string;
+  arbeidsgiverOrgnr: string;
+  utsendingsperiode?: PeriodeDto;
+  /** @format date-time */
+  innsendtDato: string;
+}
+
+export interface VentendeMotpartSoknaderResponse {
+  soknader: VentendeMotpartSoknadDto[];
+}
 
 export interface UtkastListeResponse {
   utkast: UtkastOversiktDto[];

--- a/app/src/types/representasjon.ts
+++ b/app/src/types/representasjon.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
 import type { UtsendtArbeidstakerSkjemaDto } from "~/types/melosysSkjemaTypes.ts";
-import { Representasjonstype } from "~/types/melosysSkjemaTypes.ts";
+import {
+  OpprettetVia,
+  Representasjonstype,
+} from "~/types/melosysSkjemaTypes.ts";
 
 export const representasjonskontekstSchema = z.object({
   representasjonstype: z.enum([
@@ -12,6 +15,7 @@ export const representasjonskontekstSchema = z.object({
   ]),
   radgiverOrgnr: z.coerce.string().optional(),
   arbeidsgiverOrgnr: z.coerce.string().optional(),
+  opprettetVia: z.enum(OpprettetVia).optional(),
 });
 
 export type Representasjonskontekst = z.infer<

--- a/app/src/types/representasjon.ts
+++ b/app/src/types/representasjon.ts
@@ -23,6 +23,7 @@ export const representasjonskontekstSchema = z.object({
         : undefined,
     z.enum(OpprettetVia).optional(),
   ),
+  prefyllFraSkjemaId: z.string().optional(),
 });
 
 export type Representasjonskontekst = z.infer<

--- a/app/src/types/representasjon.ts
+++ b/app/src/types/representasjon.ts
@@ -23,7 +23,14 @@ export const representasjonskontekstSchema = z.object({
         : undefined,
     z.enum(OpprettetVia).optional(),
   ),
-  prefyllFraSkjemaId: z.string().optional(),
+  // Ugyldig format droppes så opprettelsen aldri feiler på en ødelagt lenke
+  prefyllFraSkjemaId: z.preprocess(
+    (verdi) =>
+      typeof verdi === "string" && z.uuid().safeParse(verdi).success
+        ? verdi
+        : undefined,
+    z.string().optional(),
+  ),
 });
 
 export type Representasjonskontekst = z.infer<

--- a/app/src/types/representasjon.ts
+++ b/app/src/types/representasjon.ts
@@ -15,7 +15,14 @@ export const representasjonskontekstSchema = z.object({
   ]),
   radgiverOrgnr: z.coerce.string().optional(),
   arbeidsgiverOrgnr: z.coerce.string().optional(),
-  opprettetVia: z.enum(OpprettetVia).optional(),
+  // Ren statistikk-parameter: ukjente verdier ignoreres i stedet for å velte siden
+  opprettetVia: z.preprocess(
+    (verdi) =>
+      Object.values(OpprettetVia).includes(verdi as OpprettetVia)
+        ? verdi
+        : undefined,
+    z.enum(OpprettetVia).optional(),
+  ),
 });
 
 export type Representasjonskontekst = z.infer<

--- a/app/src/utils/datoformat.ts
+++ b/app/src/utils/datoformat.ts
@@ -4,27 +4,21 @@ const LOCALE_MAP: Record<string, string> = {
 };
 
 /**
- * Formaterer en ren dato-streng (YYYY-MM-DD, uten tidssone) uten å gå via
- * Date-parsing av strengen — `new Date("2026-02-01")` tolkes som UTC-midnatt
- * og gir én dag feil for brukere vest for UTC.
- */
-export function formatDato(isoDato: string, sprak: string): string {
-  const locale = LOCALE_MAP[sprak] ?? "nb-NO";
-  const [aar = 0, maaned = 1, dag = 1] = isoDato.split("-").map(Number);
-  return new Date(aar, maaned - 1, dag).toLocaleDateString(locale, {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  });
-}
-
-/**
  * Parser en ren dato-streng (YYYY-MM-DD) til lokal midnatt — `new Date("2026-02-01")`
  * tolkes som UTC-midnatt og gir én dag feil for brukere vest for UTC.
  */
 export function parseIsoDato(isoDato: string): Date {
   const [aar = 0, maaned = 1, dag = 1] = isoDato.split("-").map(Number);
   return new Date(aar, maaned - 1, dag);
+}
+
+export function formatDato(isoDato: string, sprak: string): string {
+  const locale = LOCALE_MAP[sprak] ?? "nb-NO";
+  return parseIsoDato(isoDato).toLocaleDateString(locale, {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
 }
 
 export function formatDatotid(dato: string, sprak: string): string {

--- a/app/src/utils/datoformat.ts
+++ b/app/src/utils/datoformat.ts
@@ -3,6 +3,21 @@ const LOCALE_MAP: Record<string, string> = {
   en: "en-GB",
 };
 
+/**
+ * Formaterer en ren dato-streng (YYYY-MM-DD, uten tidssone) uten å gå via
+ * Date-parsing av strengen — `new Date("2026-02-01")` tolkes som UTC-midnatt
+ * og gir én dag feil for brukere vest for UTC.
+ */
+export function formatDato(isoDato: string, sprak: string): string {
+  const locale = LOCALE_MAP[sprak] ?? "nb-NO";
+  const [aar = 0, maaned = 1, dag = 1] = isoDato.split("-").map(Number);
+  return new Date(aar, maaned - 1, dag).toLocaleDateString(locale, {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
 export function formatDatotid(dato: string, sprak: string): string {
   const locale = LOCALE_MAP[sprak] ?? "nb-NO";
   const d = new Date(dato);

--- a/app/src/utils/datoformat.ts
+++ b/app/src/utils/datoformat.ts
@@ -18,6 +18,15 @@ export function formatDato(isoDato: string, sprak: string): string {
   });
 }
 
+/**
+ * Parser en ren dato-streng (YYYY-MM-DD) til lokal midnatt — `new Date("2026-02-01")`
+ * tolkes som UTC-midnatt og gir én dag feil for brukere vest for UTC.
+ */
+export function parseIsoDato(isoDato: string): Date {
+  const [aar = 0, maaned = 1, dag = 1] = isoDato.split("-").map(Number);
+  return new Date(aar, maaned - 1, dag);
+}
+
 export function formatDatotid(dato: string, sprak: string): string {
   const locale = LOCALE_MAP[sprak] ?? "nb-NO";
   const d = new Date(dato);

--- a/app/tests/e2e/fixtures/api-mocks.ts
+++ b/app/tests/e2e/fixtures/api-mocks.ts
@@ -11,6 +11,7 @@ import type {
   UtsendtArbeidstakerMetadata,
   UtsendtArbeidstakerSkjemaDto,
   VedleggDto,
+  VentendeMotpartSoknaderResponse,
 } from "~/types/melosysSkjemaTypes";
 
 import { skjemaInnsendtKvittering } from "./test-data";
@@ -732,4 +733,35 @@ export async function setupApiMocksForOversikt(
   await mockGetEregOrganisasjon(page);
   await mockUtkastListe(page, utkast);
   await mockInnsendteSoknader(page, innsendteSoknader);
+}
+
+// ============ Feature toggles og motpart-CTA ============
+
+export async function mockFeatureToggles(
+  page: Page,
+  toggles: Record<string, boolean>,
+) {
+  await page.route(/\/api\/featuretoggle(\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(toggles),
+    });
+  });
+}
+
+export async function mockVentendeMotpartSoknader(
+  page: Page,
+  response: VentendeMotpartSoknaderResponse,
+) {
+  await page.route(
+    "/api/skjema/utsendt-arbeidstaker/ventende-motpart-soknader",
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(response),
+      });
+    },
+  );
 }

--- a/app/tests/e2e/fixtures/api-mocks.ts
+++ b/app/tests/e2e/fixtures/api-mocks.ts
@@ -735,6 +735,31 @@ export async function setupApiMocksForOversikt(
   await mockInnsendteSoknader(page, innsendteSoknader);
 }
 
+export async function mockGetEregOrganisasjonMedJuridiskEnhetPerOrgnr(
+  page: Page,
+  navnPerOrgnr: Record<string, string>,
+) {
+  await page.route(
+    "/api/ereg/organisasjon-med-juridisk-enhet/*",
+    async (route) => {
+      const orgnr =
+        route
+          .request()
+          .url()
+          .split("/api/ereg/organisasjon-med-juridisk-enhet/")[1] ?? "";
+      const navn = navnPerOrgnr[orgnr] ?? "Test Organisasjon AS";
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          organisasjon: { orgnr, navn },
+          juridiskEnhet: { orgnr, navn },
+        }),
+      });
+    },
+  );
+}
+
 // ============ Feature toggles og motpart-CTA ============
 
 export async function mockFeatureToggles(

--- a/app/tests/e2e/fixtures/test-data.ts
+++ b/app/tests/e2e/fixtures/test-data.ts
@@ -9,7 +9,6 @@ import {
   type InnsendtSkjemaResponse,
   LandKode,
   MotpartStatus,
-  OpprettetVia,
   type OrganisasjonDto,
   type OrganisasjonMedJuridiskEnhetDto,
   type PersonMedFullmaktDto,
@@ -88,7 +87,6 @@ export const testArbeidstakerSkjema: UtsendtArbeidstakerSkjemaDto = {
 export const testArbeidstakerSkjemaFraMotpartCta: UtsendtArbeidstakerSkjemaDto =
   {
     ...testArbeidstakerSkjema,
-    opprettetVia: OpprettetVia.MOTPART_CTA,
     data: {
       type: "UTSENDT_ARBEIDSTAKER_ARBEIDSTAKERS_DEL",
       utsendingsperiodeOgLand: {

--- a/app/tests/e2e/fixtures/test-data.ts
+++ b/app/tests/e2e/fixtures/test-data.ts
@@ -21,6 +21,7 @@ import {
   Sprak,
   type UtkastListeResponse,
   type UtsendtArbeidstakerSkjemaDto,
+  type VentendeMotpartSoknaderResponse,
 } from "~/types/melosysSkjemaTypes";
 
 // Gyldige organisasjonsnummer (MOD11-validert)
@@ -328,4 +329,20 @@ export const testInnsendtSkjemaKombinertDel: InnsendtSkjemaResponse = {
   definisjon: {
     seksjoner: {},
   } as unknown as InnsendtSkjemaResponse["definisjon"],
+};
+
+export const emptyVentendeMotpartSoknader: VentendeMotpartSoknaderResponse = {
+  soknader: [],
+};
+
+export const testVentendeMotpartSoknader: VentendeMotpartSoknaderResponse = {
+  soknader: [
+    {
+      skjemaId: "ventende-ag-del-1",
+      arbeidsgiverNavn: "Test Bedrift AS",
+      arbeidsgiverOrgnr: korrektFormatertOrgnr,
+      utsendingsperiode: { fraDato: "2026-02-01", tilDato: "2026-08-31" },
+      innsendtDato: "2026-01-15T09:00:00Z",
+    },
+  ],
 };

--- a/app/tests/e2e/fixtures/test-data.ts
+++ b/app/tests/e2e/fixtures/test-data.ts
@@ -9,6 +9,7 @@ import {
   type InnsendtSkjemaResponse,
   LandKode,
   MotpartStatus,
+  OpprettetVia,
   type OrganisasjonDto,
   type OrganisasjonMedJuridiskEnhetDto,
   type PersonMedFullmaktDto,
@@ -83,6 +84,23 @@ export const testArbeidstakerSkjema: UtsendtArbeidstakerSkjemaDto = {
     type: "UTSENDT_ARBEIDSTAKER_ARBEIDSTAKERS_DEL",
   },
 };
+
+export const testArbeidstakerSkjemaFraMotpartCta: UtsendtArbeidstakerSkjemaDto =
+  {
+    ...testArbeidstakerSkjema,
+    opprettetVia: OpprettetVia.MOTPART_CTA,
+    data: {
+      type: "UTSENDT_ARBEIDSTAKER_ARBEIDSTAKERS_DEL",
+      utsendingsperiodeOgLand: {
+        utsendelseLand: LandKode.SE,
+        utsendelsePeriode: { fraDato: "2026-02-01", tilDato: "2026-08-31" },
+      },
+    },
+    motpartensUtsendingsperiodeOgLand: {
+      utsendelseLand: LandKode.SE,
+      utsendelsePeriode: { fraDato: "2026-02-01", tilDato: "2026-08-31" },
+    },
+  };
 
 export const formFieldValues = {
   // Arbeidsgiver form values
@@ -342,6 +360,7 @@ export const testVentendeMotpartSoknader: VentendeMotpartSoknaderResponse = {
       arbeidsgiverNavn: "Test Bedrift AS",
       arbeidsgiverOrgnr: korrektFormatertOrgnr,
       utsendingsperiode: { fraDato: "2026-02-01", tilDato: "2026-08-31" },
+      utsendelseLand: LandKode.SE,
       innsendtDato: "2026-01-15T09:00:00Z",
     },
   ],

--- a/app/tests/e2e/fixtures/test-data.ts
+++ b/app/tests/e2e/fixtures/test-data.ts
@@ -368,7 +368,7 @@ export const emptyVentendeMotpartSoknader: VentendeMotpartSoknaderResponse = {
 export const testVentendeMotpartSoknader: VentendeMotpartSoknaderResponse = {
   soknader: [
     {
-      skjemaId: "ventende-ag-del-1",
+      skjemaId: "7f9b2c4d-1e3a-4b5c-8d6e-9f0a1b2c3d4e",
       arbeidsgiverNavn: "Test Bedrift AS",
       arbeidsgiverOrgnr: korrektFormatertOrgnr,
       utsendingsperiode: { fraDato: "2026-02-01", tilDato: "2026-08-31" },

--- a/app/tests/e2e/fixtures/test-data.ts
+++ b/app/tests/e2e/fixtures/test-data.ts
@@ -102,6 +102,18 @@ export const testArbeidstakerSkjemaFraMotpartCta: UtsendtArbeidstakerSkjemaDto =
     },
   };
 
+export const testArbeidstakerSkjemaMedAvvikFraMotpart: UtsendtArbeidstakerSkjemaDto =
+  {
+    ...testArbeidstakerSkjemaFraMotpartCta,
+    data: {
+      type: "UTSENDT_ARBEIDSTAKER_ARBEIDSTAKERS_DEL",
+      utsendingsperiodeOgLand: {
+        utsendelseLand: LandKode.DE,
+        utsendelsePeriode: { fraDato: "2026-03-01", tilDato: "2026-09-30" },
+      },
+    },
+  };
+
 export const formFieldValues = {
   // Arbeidsgiver form values
   organisasjonsnummer: testOrganization.orgnr,

--- a/app/tests/e2e/pages/oversikt/oversikt.page.ts
+++ b/app/tests/e2e/pages/oversikt/oversikt.page.ts
@@ -468,6 +468,18 @@ export class OversiktPage {
     await expect(this.motpartCtaHeading(arbeidsgiverNavn)).toBeVisible();
   }
 
+  async assertMotpartCtaBeskrivelseVisible(
+    land: string,
+    fraDato: string,
+    tilDato: string,
+  ) {
+    const tekst = translations.oversiktDegSelv.motpartCtaBeskrivelse
+      .replace("{{land}}", land)
+      .replace("{{fraDato}}", fraDato)
+      .replace("{{tilDato}}", tilDato);
+    await expect(this.page.getByText(tekst)).toBeVisible();
+  }
+
   async assertMotpartCtaNotVisible(arbeidsgiverNavn: string) {
     await expect(this.motpartCtaHeading(arbeidsgiverNavn)).not.toBeVisible();
   }

--- a/app/tests/e2e/pages/oversikt/oversikt.page.ts
+++ b/app/tests/e2e/pages/oversikt/oversikt.page.ts
@@ -436,4 +436,35 @@ export class OversiktPage {
       ),
     ).toBeVisible();
   }
+
+  // ============ Motpart-CTA ============
+
+  private motpartCtaHeading(arbeidsgiverNavn: string) {
+    return this.page.getByRole("heading", {
+      name: translations.oversiktDegSelv.motpartCtaTittel.replace(
+        "{{arbeidsgiverNavn}}",
+        arbeidsgiverNavn,
+      ),
+    });
+  }
+
+  async assertMotpartCtaVisible(arbeidsgiverNavn: string) {
+    await expect(this.motpartCtaHeading(arbeidsgiverNavn)).toBeVisible();
+  }
+
+  async assertMotpartCtaNotVisible(arbeidsgiverNavn: string) {
+    await expect(this.motpartCtaHeading(arbeidsgiverNavn)).not.toBeVisible();
+  }
+
+  async clickMotpartCtaFyllUtDinDel() {
+    await this.page
+      .getByRole("button", {
+        name: translations.oversiktDegSelv.motpartCtaKnapp,
+      })
+      .click();
+  }
+
+  async assertArbeidsgiverOrgnrPrefilt(orgnr: string) {
+    await expect(this.arbeidsgiverOrgnrInput).toHaveValue(orgnr);
+  }
 }

--- a/app/tests/e2e/pages/oversikt/oversikt.page.ts
+++ b/app/tests/e2e/pages/oversikt/oversikt.page.ts
@@ -439,6 +439,22 @@ export class OversiktPage {
 
   // ============ Motpart-CTA ============
 
+  /**
+   * Start disse FØR goto() — negative assertions er ellers racy mot
+   * featuretoggle-/ventende-queriene som avgjør om banneret rendres.
+   */
+  ventPaaFeatureToggles(): Promise<unknown> {
+    return this.page.waitForResponse((response) =>
+      response.url().includes("/api/featuretoggle"),
+    );
+  }
+
+  ventPaaVentendeMotpartSoknader(): Promise<unknown> {
+    return this.page.waitForResponse((response) =>
+      response.url().includes("/ventende-motpart-soknader"),
+    );
+  }
+
   private motpartCtaHeading(arbeidsgiverNavn: string) {
     return this.page.getByRole("heading", {
       name: translations.oversiktDegSelv.motpartCtaTittel.replace(

--- a/app/tests/e2e/pages/representasjon/representasjon.page.ts
+++ b/app/tests/e2e/pages/representasjon/representasjon.page.ts
@@ -39,6 +39,18 @@ export class RepresentasjonPage {
     await expect(this.heading).toBeVisible();
   }
 
+  async assertSoknadVenterBadgeVisible() {
+    await expect(
+      this.degSelvButton.getByText(translations.soknadVenterPaaDeg),
+    ).toBeVisible();
+  }
+
+  async assertSoknadVenterBadgeNotVisible() {
+    await expect(
+      this.degSelvButton.getByText(translations.soknadVenterPaaDeg),
+    ).not.toBeVisible();
+  }
+
   async velgDegSelv() {
     await this.degSelvButton.click();
   }

--- a/app/tests/e2e/pages/representasjon/representasjon.page.ts
+++ b/app/tests/e2e/pages/representasjon/representasjon.page.ts
@@ -39,6 +39,22 @@ export class RepresentasjonPage {
     await expect(this.heading).toBeVisible();
   }
 
+  /**
+   * Start disse FØR goto() — negative badge-assertions er ellers racy mot
+   * featuretoggle-/ventende-queriene som avgjør om badgen rendres.
+   */
+  ventPaaFeatureToggles(): Promise<unknown> {
+    return this.page.waitForResponse((response) =>
+      response.url().includes("/api/featuretoggle"),
+    );
+  }
+
+  ventPaaVentendeMotpartSoknader(): Promise<unknown> {
+    return this.page.waitForResponse((response) =>
+      response.url().includes("/ventende-motpart-soknader"),
+    );
+  }
+
   async assertSoknadVenterBadgeVisible() {
     await expect(
       this.degSelvButton.getByText(translations.soknadVenterPaaDeg),

--- a/app/tests/e2e/pages/skjema/utsendingsperiode-og-land-steg.page.ts
+++ b/app/tests/e2e/pages/skjema/utsendingsperiode-og-land-steg.page.ts
@@ -103,6 +103,30 @@ export class UtsendingsperiodeOgLandStegPage {
     await expect(this.utsendelseLandCombobox).not.toBeVisible();
   }
 
+  async assertArbeidsgiverOppgaLandVisible(land: string) {
+    await expect(
+      this.page.getByText(
+        nb.translation.utsendingsperiodeOgLandSteg.arbeidsgiverOppgaLand.replace(
+          "{{land}}",
+          land,
+        ),
+      ),
+    ).toBeVisible();
+  }
+
+  async assertArbeidsgiverOppgaPeriodeVisible(
+    fraDato: string,
+    tilDato: string,
+  ) {
+    await expect(
+      this.page.getByText(
+        nb.translation.utsendingsperiodeOgLandSteg.arbeidsgiverOppgaPeriode
+          .replace("{{fraDato}}", fraDato)
+          .replace("{{tilDato}}", tilDato),
+      ),
+    ).toBeVisible();
+  }
+
   async clickEndreLandEllerPeriode() {
     await this.page
       .getByRole("button", {

--- a/app/tests/e2e/pages/skjema/utsendingsperiode-og-land-steg.page.ts
+++ b/app/tests/e2e/pages/skjema/utsendingsperiode-og-land-steg.page.ts
@@ -58,6 +58,63 @@ export class UtsendingsperiodeOgLandStegPage {
     await expect(this.heading).toBeVisible();
   }
 
+  private preutfyltInfoboksTekst(
+    land: string,
+    fraDato: string,
+    tilDato: string,
+  ) {
+    return nb.translation.utsendingsperiodeOgLandSteg.preutfyltAvArbeidsgiver
+      .replace("{{land}}", land)
+      .replace("{{fraDato}}", fraDato)
+      .replace("{{tilDato}}", tilDato);
+  }
+
+  async assertPreutfyltInfoboksVisible(
+    land: string,
+    fraDato: string,
+    tilDato: string,
+  ) {
+    await expect(
+      this.page.getByText(this.preutfyltInfoboksTekst(land, fraDato, tilDato)),
+    ).toBeVisible();
+  }
+
+  async assertPreutfyltInfoboksNotVisible() {
+    await expect(
+      this.page.getByText(
+        nb.translation.utsendingsperiodeOgLandSteg.preutfyltAvArbeidsgiver.split(
+          "{{land}}",
+        )[0] ?? "Arbeidsgiveren din har oppgitt",
+      ),
+    ).not.toBeVisible();
+  }
+
+  async assertLandValgt(landKode: string) {
+    await expect(this.utsendelseLandCombobox).toHaveValue(landKode);
+  }
+
+  async assertLesevisningVisible(landNavn: string) {
+    await expect(
+      this.page.getByRole("button", {
+        name: nb.translation.utsendingsperiodeOgLandSteg.endreLandEllerPeriode,
+      }),
+    ).toBeVisible();
+    await expect(this.page.getByText(landNavn, { exact: true })).toBeVisible();
+    await expect(this.utsendelseLandCombobox).not.toBeVisible();
+  }
+
+  async clickEndreLandEllerPeriode() {
+    await this.page
+      .getByRole("button", {
+        name: nb.translation.utsendingsperiodeOgLandSteg.endreLandEllerPeriode,
+      })
+      .click();
+  }
+
+  async assertFraDatoValue(dato: string) {
+    await expect(this.fraDatoInput).toHaveValue(dato);
+  }
+
   async velgLand(land: { label: string; value: string }) {
     await this.utsendelseLandCombobox.selectOption(land);
   }

--- a/app/tests/e2e/specs/oversikt-motpart-cta.spec.ts
+++ b/app/tests/e2e/specs/oversikt-motpart-cta.spec.ts
@@ -83,6 +83,7 @@ test.describe("Oversikt — motpart-CTA", () => {
 
     const requestBody = (await requestBodyPromise) as Record<string, unknown>;
     expect(requestBody.opprettetVia).toBe(OpprettetVia.MOTPART_CTA);
+    expect(requestBody.prefyllFraSkjemaId).toBe("ventende-ag-del-1");
     expect(requestBody.arbeidsgiver).toEqual({
       orgnr: korrektFormatertOrgnr,
       navn: "Test Organisasjon AS",
@@ -116,6 +117,7 @@ test.describe("Oversikt — motpart-CTA", () => {
 
     const requestBody = (await requestBodyPromise) as Record<string, unknown>;
     expect(requestBody.opprettetVia).toBeUndefined();
+    expect(requestBody.prefyllFraSkjemaId).toBeUndefined();
     expect(requestBody.arbeidsgiver).toEqual({
       orgnr: korrektFormatertOrgnr2,
       navn: "Annen Arbeidsgiver AS",

--- a/app/tests/e2e/specs/oversikt-motpart-cta.spec.ts
+++ b/app/tests/e2e/specs/oversikt-motpart-cta.spec.ts
@@ -1,0 +1,129 @@
+import { Representasjonstype } from "~/types/melosysSkjemaTypes";
+
+import {
+  mockFeatureToggles,
+  mockGetEregOrganisasjonMedJuridiskEnhet,
+  mockUserInfo,
+  mockVentendeMotpartSoknader,
+  setupApiMocksForOversikt,
+} from "../fixtures/api-mocks";
+import { test } from "../fixtures/test";
+import {
+  emptyInnsendteSoknader,
+  emptyUtkastListe,
+  emptyVentendeMotpartSoknader,
+  korrektFormatertOrgnr,
+  testUserInfo,
+  testVentendeMotpartSoknader,
+} from "../fixtures/test-data";
+import { OversiktPage } from "../pages/oversikt/oversikt.page";
+import { RepresentasjonPage } from "../pages/representasjon/representasjon.page";
+
+const ALLE_TOGGLES_PAA = {
+  "melosys.skjema.motpart-cta": true,
+  "melosys.skjema.innsendt-sammendrag": true,
+};
+
+const MOTPART_CTA_AV = {
+  "melosys.skjema.motpart-cta": false,
+  "melosys.skjema.innsendt-sammendrag": true,
+};
+
+test.describe("Oversikt — motpart-CTA", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupApiMocksForOversikt(
+      page,
+      testUserInfo,
+      [],
+      emptyUtkastListe,
+      emptyInnsendteSoknader,
+    );
+    await mockGetEregOrganisasjonMedJuridiskEnhet(page);
+  });
+
+  test("Viser banner for DEG_SELV og prefiller arbeidsgiver ved klikk", async ({
+    page,
+  }) => {
+    await mockFeatureToggles(page, ALLE_TOGGLES_PAA);
+    await mockVentendeMotpartSoknader(page, testVentendeMotpartSoknader);
+
+    const oversiktPage = new OversiktPage(page, Representasjonstype.DEG_SELV);
+    await oversiktPage.goto();
+    await oversiktPage.assertIsVisible();
+    await oversiktPage.assertMotpartCtaVisible("Test Bedrift AS");
+
+    await oversiktPage.clickMotpartCtaFyllUtDinDel();
+    await oversiktPage.assertArbeidsgiverOrgnrPrefilt(korrektFormatertOrgnr);
+  });
+
+  test("Viser ikke banner når toggle er av", async ({ page }) => {
+    await mockFeatureToggles(page, MOTPART_CTA_AV);
+    await mockVentendeMotpartSoknader(page, testVentendeMotpartSoknader);
+
+    const oversiktPage = new OversiktPage(page, Representasjonstype.DEG_SELV);
+    await oversiktPage.goto();
+    await oversiktPage.assertIsVisible();
+    await oversiktPage.assertMotpartCtaNotVisible("Test Bedrift AS");
+  });
+
+  test("Viser ikke banner uten ventende motpart-søknader", async ({ page }) => {
+    await mockFeatureToggles(page, ALLE_TOGGLES_PAA);
+    await mockVentendeMotpartSoknader(page, emptyVentendeMotpartSoknader);
+
+    const oversiktPage = new OversiktPage(page, Representasjonstype.DEG_SELV);
+    await oversiktPage.goto();
+    await oversiktPage.assertIsVisible();
+    await oversiktPage.assertMotpartCtaNotVisible("Test Bedrift AS");
+  });
+
+  test("Viser ikke banner for ARBEIDSGIVER-kontekst", async ({ page }) => {
+    await mockFeatureToggles(page, ALLE_TOGGLES_PAA);
+    await mockVentendeMotpartSoknader(page, testVentendeMotpartSoknader);
+
+    const oversiktPage = new OversiktPage(
+      page,
+      Representasjonstype.ARBEIDSGIVER,
+    );
+    await oversiktPage.goto();
+    await oversiktPage.assertIsVisible();
+    await oversiktPage.assertMotpartCtaNotVisible("Test Bedrift AS");
+  });
+});
+
+test.describe("Landingsside — motpart-hint", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockUserInfo(page, testUserInfo);
+  });
+
+  test("Viser «Søknad venter på deg» på DEG_SELV-kortet ved treff", async ({
+    page,
+  }) => {
+    await mockFeatureToggles(page, ALLE_TOGGLES_PAA);
+    await mockVentendeMotpartSoknader(page, testVentendeMotpartSoknader);
+
+    const representasjonPage = new RepresentasjonPage(page);
+    await representasjonPage.goto();
+    await representasjonPage.assertIsVisible();
+    await representasjonPage.assertSoknadVenterBadgeVisible();
+  });
+
+  test("Viser ikke hint når toggle er av", async ({ page }) => {
+    await mockFeatureToggles(page, MOTPART_CTA_AV);
+    await mockVentendeMotpartSoknader(page, testVentendeMotpartSoknader);
+
+    const representasjonPage = new RepresentasjonPage(page);
+    await representasjonPage.goto();
+    await representasjonPage.assertIsVisible();
+    await representasjonPage.assertSoknadVenterBadgeNotVisible();
+  });
+
+  test("Viser ikke hint uten ventende motpart-søknader", async ({ page }) => {
+    await mockFeatureToggles(page, ALLE_TOGGLES_PAA);
+    await mockVentendeMotpartSoknader(page, emptyVentendeMotpartSoknader);
+
+    const representasjonPage = new RepresentasjonPage(page);
+    await representasjonPage.goto();
+    await representasjonPage.assertIsVisible();
+    await representasjonPage.assertSoknadVenterBadgeNotVisible();
+  });
+});

--- a/app/tests/e2e/specs/oversikt-motpart-cta.spec.ts
+++ b/app/tests/e2e/specs/oversikt-motpart-cta.spec.ts
@@ -123,7 +123,7 @@ test.describe("Oversikt — motpart-CTA", () => {
     await oversiktPage.clickStartSoknad();
 
     const requestBody = (await requestBodyPromise) as Record<string, unknown>;
-    expect(requestBody.opprettetVia).toBeUndefined();
+    expect(requestBody.opprettetVia).toBe(OpprettetVia.ORDINAER);
     expect(requestBody.prefyllFraSkjemaId).toBeUndefined();
     expect(requestBody.arbeidsgiver).toEqual({
       orgnr: korrektFormatertOrgnr2,

--- a/app/tests/e2e/specs/oversikt-motpart-cta.spec.ts
+++ b/app/tests/e2e/specs/oversikt-motpart-cta.spec.ts
@@ -57,6 +57,11 @@ test.describe("Oversikt — motpart-CTA", () => {
     await oversiktPage.goto();
     await oversiktPage.assertIsVisible();
     await oversiktPage.assertMotpartCtaVisible("Test Bedrift AS");
+    await oversiktPage.assertMotpartCtaBeskrivelseVisible(
+      "Sverige",
+      "01.02.2026",
+      "31.08.2026",
+    );
 
     await oversiktPage.clickMotpartCtaFyllUtDinDel();
     await oversiktPage.assertArbeidsgiverOrgnrPrefilt(korrektFormatertOrgnr);
@@ -83,7 +88,9 @@ test.describe("Oversikt — motpart-CTA", () => {
 
     const requestBody = (await requestBodyPromise) as Record<string, unknown>;
     expect(requestBody.opprettetVia).toBe(OpprettetVia.MOTPART_CTA);
-    expect(requestBody.prefyllFraSkjemaId).toBe("ventende-ag-del-1");
+    expect(requestBody.prefyllFraSkjemaId).toBe(
+      "7f9b2c4d-1e3a-4b5c-8d6e-9f0a1b2c3d4e",
+    );
     expect(requestBody.arbeidsgiver).toEqual({
       orgnr: korrektFormatertOrgnr,
       navn: "Test Organisasjon AS",

--- a/app/tests/e2e/specs/oversikt-motpart-cta.spec.ts
+++ b/app/tests/e2e/specs/oversikt-motpart-cta.spec.ts
@@ -1,18 +1,23 @@
-import { Representasjonstype } from "~/types/melosysSkjemaTypes";
+import { OpprettetVia, Representasjonstype } from "~/types/melosysSkjemaTypes";
 
 import {
+  interceptOpprettSoknad,
   mockFeatureToggles,
   mockGetEregOrganisasjonMedJuridiskEnhet,
+  mockGetEregOrganisasjonMedJuridiskEnhetPerOrgnr,
+  mockPersonerMedFullmakt,
   mockUserInfo,
   mockVentendeMotpartSoknader,
   setupApiMocksForOversikt,
 } from "../fixtures/api-mocks";
-import { test } from "../fixtures/test";
+import { expect, test } from "../fixtures/test";
 import {
   emptyInnsendteSoknader,
   emptyUtkastListe,
   emptyVentendeMotpartSoknader,
   korrektFormatertOrgnr,
+  korrektFormatertOrgnr2,
+  testOpprettSoknadResponseId,
   testUserInfo,
   testVentendeMotpartSoknader,
 } from "../fixtures/test-data";
@@ -39,6 +44,7 @@ test.describe("Oversikt — motpart-CTA", () => {
       emptyInnsendteSoknader,
     );
     await mockGetEregOrganisasjonMedJuridiskEnhet(page);
+    await mockPersonerMedFullmakt(page, []);
   });
 
   test("Viser banner for DEG_SELV og prefiller arbeidsgiver ved klikk", async ({
@@ -56,12 +62,74 @@ test.describe("Oversikt — motpart-CTA", () => {
     await oversiktPage.assertArbeidsgiverOrgnrPrefilt(korrektFormatertOrgnr);
   });
 
+  test("Opprettelse via CTA sender opprettetVia i payload", async ({
+    page,
+  }) => {
+    await mockFeatureToggles(page, ALLE_TOGGLES_PAA);
+    await mockVentendeMotpartSoknader(page, testVentendeMotpartSoknader);
+    const requestBodyPromise = interceptOpprettSoknad(
+      page,
+      testOpprettSoknadResponseId,
+    );
+
+    const oversiktPage = new OversiktPage(page, Representasjonstype.DEG_SELV);
+    await oversiktPage.goto();
+    await oversiktPage.assertIsVisible();
+    await oversiktPage.clickMotpartCtaFyllUtDinDel();
+    await oversiktPage.assertArbeidsgiverOrgnrPrefilt(korrektFormatertOrgnr);
+    await oversiktPage.waitForOrgLookup("Test Organisasjon AS");
+    await oversiktPage.checkBekreftelseCheckbox();
+    await oversiktPage.clickStartSoknad();
+
+    const requestBody = (await requestBodyPromise) as Record<string, unknown>;
+    expect(requestBody.opprettetVia).toBe(OpprettetVia.MOTPART_CTA);
+    expect(requestBody.arbeidsgiver).toEqual({
+      orgnr: korrektFormatertOrgnr,
+      navn: "Test Organisasjon AS",
+    });
+  });
+
+  test("Bytter brukeren arbeidsgiver etter CTA-klikk, sendes ikke opprettetVia", async ({
+    page,
+  }) => {
+    await mockFeatureToggles(page, ALLE_TOGGLES_PAA);
+    await mockVentendeMotpartSoknader(page, testVentendeMotpartSoknader);
+    await mockGetEregOrganisasjonMedJuridiskEnhetPerOrgnr(page, {
+      [korrektFormatertOrgnr]: "CTA Arbeidsgiver AS",
+      [korrektFormatertOrgnr2]: "Annen Arbeidsgiver AS",
+    });
+    const requestBodyPromise = interceptOpprettSoknad(
+      page,
+      testOpprettSoknadResponseId,
+    );
+
+    const oversiktPage = new OversiktPage(page, Representasjonstype.DEG_SELV);
+    await oversiktPage.goto();
+    await oversiktPage.assertIsVisible();
+    await oversiktPage.clickMotpartCtaFyllUtDinDel();
+    await oversiktPage.waitForOrgLookup("CTA Arbeidsgiver AS");
+
+    await oversiktPage.fillArbeidsgiverOrgnr(korrektFormatertOrgnr2);
+    await oversiktPage.waitForOrgLookup("Annen Arbeidsgiver AS");
+    await oversiktPage.checkBekreftelseCheckbox();
+    await oversiktPage.clickStartSoknad();
+
+    const requestBody = (await requestBodyPromise) as Record<string, unknown>;
+    expect(requestBody.opprettetVia).toBeUndefined();
+    expect(requestBody.arbeidsgiver).toEqual({
+      orgnr: korrektFormatertOrgnr2,
+      navn: "Annen Arbeidsgiver AS",
+    });
+  });
+
   test("Viser ikke banner når toggle er av", async ({ page }) => {
     await mockFeatureToggles(page, MOTPART_CTA_AV);
     await mockVentendeMotpartSoknader(page, testVentendeMotpartSoknader);
 
     const oversiktPage = new OversiktPage(page, Representasjonstype.DEG_SELV);
+    const togglesLastet = oversiktPage.ventPaaFeatureToggles();
     await oversiktPage.goto();
+    await togglesLastet;
     await oversiktPage.assertIsVisible();
     await oversiktPage.assertMotpartCtaNotVisible("Test Bedrift AS");
   });
@@ -71,7 +139,9 @@ test.describe("Oversikt — motpart-CTA", () => {
     await mockVentendeMotpartSoknader(page, emptyVentendeMotpartSoknader);
 
     const oversiktPage = new OversiktPage(page, Representasjonstype.DEG_SELV);
+    const ventendeLastet = oversiktPage.ventPaaVentendeMotpartSoknader();
     await oversiktPage.goto();
+    await ventendeLastet;
     await oversiktPage.assertIsVisible();
     await oversiktPage.assertMotpartCtaNotVisible("Test Bedrift AS");
   });
@@ -84,7 +154,9 @@ test.describe("Oversikt — motpart-CTA", () => {
       page,
       Representasjonstype.ARBEIDSGIVER,
     );
+    const togglesLastet = oversiktPage.ventPaaFeatureToggles();
     await oversiktPage.goto();
+    await togglesLastet;
     await oversiktPage.assertIsVisible();
     await oversiktPage.assertMotpartCtaNotVisible("Test Bedrift AS");
   });
@@ -112,7 +184,9 @@ test.describe("Landingsside — motpart-hint", () => {
     await mockVentendeMotpartSoknader(page, testVentendeMotpartSoknader);
 
     const representasjonPage = new RepresentasjonPage(page);
+    const togglesLastet = representasjonPage.ventPaaFeatureToggles();
     await representasjonPage.goto();
+    await togglesLastet;
     await representasjonPage.assertIsVisible();
     await representasjonPage.assertSoknadVenterBadgeNotVisible();
   });
@@ -122,7 +196,9 @@ test.describe("Landingsside — motpart-hint", () => {
     await mockVentendeMotpartSoknader(page, emptyVentendeMotpartSoknader);
 
     const representasjonPage = new RepresentasjonPage(page);
+    const ventendeLastet = representasjonPage.ventPaaVentendeMotpartSoknader();
     await representasjonPage.goto();
+    await ventendeLastet;
     await representasjonPage.assertIsVisible();
     await representasjonPage.assertSoknadVenterBadgeNotVisible();
   });

--- a/app/tests/e2e/specs/oversikt.spec.ts
+++ b/app/tests/e2e/specs/oversikt.spec.ts
@@ -1,5 +1,5 @@
 import { nb } from "~/i18n/nb";
-import { Representasjonstype } from "~/types/melosysSkjemaTypes";
+import { OpprettetVia, Representasjonstype } from "~/types/melosysSkjemaTypes";
 
 import {
   interceptOpprettSoknad,
@@ -280,6 +280,7 @@ test.describe("Oversikt — Start søknad POST-payload", () => {
 
     // Assert POST payload
     expect(requestBody).toEqual({
+      opprettetVia: OpprettetVia.ORDINAER,
       representasjonstype: Representasjonstype.DEG_SELV,
       arbeidsgiver: {
         orgnr: testEregOrganisasjon.juridiskEnhet.orgnr,
@@ -337,6 +338,7 @@ test.describe("Oversikt — Start søknad POST-payload", () => {
 
     // Assert POST payload — skalFylleUtForArbeidstaker=false means no fullmakt transform
     expect(requestBody).toEqual({
+      opprettetVia: OpprettetVia.ORDINAER,
       representasjonstype: Representasjonstype.ARBEIDSGIVER,
       arbeidsgiver: {
         orgnr: testArbeidsgiverOrganization.orgnr,
@@ -395,6 +397,7 @@ test.describe("Oversikt — Start søknad POST-payload", () => {
 
     // Assert POST payload — skalFylleUtForArbeidstaker=true triggers ARBEIDSGIVER_MED_FULLMAKT
     expect(requestBody).toEqual({
+      opprettetVia: OpprettetVia.ORDINAER,
       representasjonstype: Representasjonstype.ARBEIDSGIVER_MED_FULLMAKT,
       arbeidsgiver: {
         orgnr: testArbeidsgiverOrganization.orgnr,
@@ -455,6 +458,7 @@ test.describe("Oversikt — Start søknad POST-payload", () => {
 
     // Assert POST payload — includes radgiverfirma, no fullmakt transform
     expect(requestBody).toEqual({
+      opprettetVia: OpprettetVia.ORDINAER,
       representasjonstype: Representasjonstype.RADGIVER,
       radgiverfirma: {
         orgnr: testRadgiverfirmaOrganisasjon.juridiskEnhet.orgnr,
@@ -514,6 +518,7 @@ test.describe("Oversikt — Start søknad POST-payload", () => {
 
     // Assert POST payload — includes radgiverfirma, fullmakt transform applies
     expect(requestBody).toEqual({
+      opprettetVia: OpprettetVia.ORDINAER,
       representasjonstype: Representasjonstype.RADGIVER_MED_FULLMAKT,
       radgiverfirma: {
         orgnr: testRadgiverfirmaOrganisasjon.juridiskEnhet.orgnr,

--- a/app/tests/e2e/specs/skjema/utsendingsperiode-og-land.spec.ts
+++ b/app/tests/e2e/specs/skjema/utsendingsperiode-og-land.spec.ts
@@ -5,6 +5,7 @@ import { test } from "../../fixtures/test";
 import {
   formFieldValues,
   testArbeidstakerSkjema,
+  testArbeidstakerSkjemaFraMotpartCta,
   testUserInfo,
 } from "../../fixtures/test-data";
 import { UtsendingsperiodeOgLandStegPage } from "../../pages/skjema/utsendingsperiode-og-land-steg.page";
@@ -16,6 +17,43 @@ test.describe("Utsendingsperiode og land", () => {
       testArbeidstakerSkjema,
       testUserInfo,
     );
+  });
+
+  test("skjema startet via motpart-CTA viser infoboks med motpartens verdier og prefilte felter", async ({
+    page,
+  }) => {
+    await setupApiMocksForArbeidstaker(
+      page,
+      testArbeidstakerSkjemaFraMotpartCta,
+      testUserInfo,
+    );
+
+    const stegPage = new UtsendingsperiodeOgLandStegPage(
+      page,
+      testArbeidstakerSkjemaFraMotpartCta,
+    );
+    await stegPage.goto();
+    await stegPage.assertIsVisible();
+    await stegPage.assertPreutfyltInfoboksVisible(
+      "Sverige",
+      "01.02.2026",
+      "31.08.2026",
+    );
+    await stegPage.assertLesevisningVisible("Sverige");
+
+    await stegPage.clickEndreLandEllerPeriode();
+    await stegPage.assertLandValgt("SE");
+    await stegPage.assertFraDatoValue("01.02.2026");
+  });
+
+  test("vanlig skjema viser ikke preutfylt-infoboks", async ({ page }) => {
+    const stegPage = new UtsendingsperiodeOgLandStegPage(
+      page,
+      testArbeidstakerSkjema,
+    );
+    await stegPage.goto();
+    await stegPage.assertIsVisible();
+    await stegPage.assertPreutfyltInfoboksNotVisible();
   });
 
   test("happy case - fyller ut land og periode og gjør forventet POST request", async ({

--- a/app/tests/e2e/specs/skjema/utsendingsperiode-og-land.spec.ts
+++ b/app/tests/e2e/specs/skjema/utsendingsperiode-og-land.spec.ts
@@ -6,6 +6,7 @@ import {
   formFieldValues,
   testArbeidstakerSkjema,
   testArbeidstakerSkjemaFraMotpartCta,
+  testArbeidstakerSkjemaMedAvvikFraMotpart,
   testUserInfo,
 } from "../../fixtures/test-data";
 import { UtsendingsperiodeOgLandStegPage } from "../../pages/skjema/utsendingsperiode-og-land-steg.page";
@@ -44,6 +45,29 @@ test.describe("Utsendingsperiode og land", () => {
     await stegPage.clickEndreLandEllerPeriode();
     await stegPage.assertLandValgt("SE");
     await stegPage.assertFraDatoValue("01.02.2026");
+  });
+
+  test("viser avviks-info når lagrede verdier avviker fra motpartens", async ({
+    page,
+  }) => {
+    await setupApiMocksForArbeidstaker(
+      page,
+      testArbeidstakerSkjemaMedAvvikFraMotpart,
+      testUserInfo,
+    );
+
+    const stegPage = new UtsendingsperiodeOgLandStegPage(
+      page,
+      testArbeidstakerSkjemaMedAvvikFraMotpart,
+    );
+    await stegPage.goto();
+    await stegPage.assertIsVisible();
+    await stegPage.assertArbeidsgiverOppgaLandVisible("Sverige");
+    await stegPage.assertArbeidsgiverOppgaPeriodeVisible(
+      "01.02.2026",
+      "31.08.2026",
+    );
+    await stegPage.assertLandValgt("DE");
   });
 
   test("vanlig skjema viser ikke preutfylt-infoboks", async ({ page }) => {

--- a/app/tests/e2e/specs/skjema/utsendingsperiode-og-land.spec.ts
+++ b/app/tests/e2e/specs/skjema/utsendingsperiode-og-land.spec.ts
@@ -1,4 +1,7 @@
-import { UtsendingsperiodeOgLandDto } from "~/types/melosysSkjemaTypes";
+import {
+  LandKode,
+  UtsendingsperiodeOgLandDto,
+} from "~/types/melosysSkjemaTypes";
 
 import { setupApiMocksForArbeidstaker } from "../../fixtures/api-mocks";
 import { test } from "../../fixtures/test";
@@ -45,6 +48,51 @@ test.describe("Utsendingsperiode og land", () => {
     await stegPage.clickEndreLandEllerPeriode();
     await stegPage.assertLandValgt("SE");
     await stegPage.assertFraDatoValue("01.02.2026");
+  });
+
+  test("Neste i lesevisning sender motpartens verdier uendret", async ({
+    page,
+  }) => {
+    await setupApiMocksForArbeidstaker(
+      page,
+      testArbeidstakerSkjemaFraMotpartCta,
+      testUserInfo,
+    );
+
+    const stegPage = new UtsendingsperiodeOgLandStegPage(
+      page,
+      testArbeidstakerSkjemaFraMotpartCta,
+    );
+    await stegPage.goto();
+    await stegPage.assertIsVisible();
+    await stegPage.assertLesevisningVisible("Sverige");
+
+    await stegPage.lagreOgFortsettAndExpectPayload({
+      utsendelseLand: LandKode.SE,
+      utsendelsePeriode: { fraDato: "2026-02-01", tilDato: "2026-08-31" },
+    });
+    await stegPage.assertNavigatedToNextStep();
+  });
+
+  test("viser live avviks-info under landfeltet når bruker endrer land", async ({
+    page,
+  }) => {
+    await setupApiMocksForArbeidstaker(
+      page,
+      testArbeidstakerSkjemaFraMotpartCta,
+      testUserInfo,
+    );
+
+    const stegPage = new UtsendingsperiodeOgLandStegPage(
+      page,
+      testArbeidstakerSkjemaFraMotpartCta,
+    );
+    await stegPage.goto();
+    await stegPage.assertIsVisible();
+    await stegPage.clickEndreLandEllerPeriode();
+
+    await stegPage.velgLand({ label: "Tyskland", value: LandKode.DE });
+    await stegPage.assertArbeidsgiverOppgaLandVisible("Sverige");
   });
 
   test("viser avviks-info når lagrede verdier avviker fra motpartens", async ({


### PR DESCRIPTION
- Banner for DEG_SELV når arbeidsgiver har sendt sin del: «Fyll ut din del» med orgnr-prefill (bak toggle `melosys.skjema.motpart-cta`)
- Hint-badge «Søknad venter på deg» på DEG_SELV-kortet på landingssiden
- `opprettetVia` sendes ved opprettelse via CTA (kun ved uendret arbeidsgiver)